### PR TITLE
PAMS-142 and PAMS-174 changes

### DIFF
--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/AlertEngineImplTest.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/AlertEngineImplTest.scala
@@ -202,14 +202,26 @@ class AlertEngineImplTest
         |    - test@phdata.io
         |  """.stripMargin
 
-    val app1 = AlertEngineConfigParser.convert(yaml).applications(0)
-    val app2 = AlertEngineConfigParser.convert(yaml).applications(1)
-
     val triggeredAlerts =
       List(
-        (app1, Option(TriggeredAlert(app1.alertRules(0), "spark1", null, 1))),
-        (app2, Option(TriggeredAlert(app2.alertRules(0), "spark2", null, 2))),
-        (app2, Option(TriggeredAlert(app2.alertRules(1), "spark2", null, 2)))
+        (AlertEngineConfigParser.convert(yaml).applications(0),
+         Option(
+           TriggeredAlert(AlertEngineConfigParser.convert(yaml).applications(0).alertRules(0),
+                          "spark1",
+                          null,
+                          1))),
+        (AlertEngineConfigParser.convert(yaml).applications(1),
+         Option(
+           TriggeredAlert(AlertEngineConfigParser.convert(yaml).applications(1).alertRules(0),
+                          "spark2",
+                          null,
+                          2))),
+        (AlertEngineConfigParser.convert(yaml).applications(1),
+         Option(
+           TriggeredAlert(AlertEngineConfigParser.convert(yaml).applications(1).alertRules(1),
+                          "spark2",
+                          null,
+                          2)))
       )
 
     val groupedTriggerdAlerts =
@@ -218,6 +230,7 @@ class AlertEngineImplTest
     assert(groupedTriggerdAlerts.size == 2)
     assert(groupedTriggerdAlerts.head._2.size == 1)
     assert(groupedTriggerdAlerts.tail.head._2.size == 2)
+
   }
 
   test("Silenced applications alerts aren't checked") {

--- a/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRoller.scala
+++ b/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRoller.scala
@@ -287,4 +287,12 @@ class CollectionRoller(solrService: SolrService, val now: ZonedDateTime) extends
       .map(x => x.split("_")(0))
       .toList
 
+  /**
+   * List all aliases belonging to an application
+   * @return The list of collection names
+   */
+  def aliasMap(): Map[String, Set[String]] =
+    solrService
+      .listAliases()
+
 }

--- a/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRoller.scala
+++ b/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRoller.scala
@@ -289,7 +289,7 @@ class CollectionRoller(solrService: SolrService, val now: ZonedDateTime) extends
 
   /**
    * List all aliases belonging to an application
-   * @return The list of collection names
+   * @return Map of alias names as keys and collection names as Set[String]
    */
   def aliasMap(): Map[String, Set[String]] =
     solrService

--- a/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRollerCliParser.scala
+++ b/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRollerCliParser.scala
@@ -34,9 +34,9 @@ class CollectionRollerCliArgsParser(args: Seq[String]) extends ScallopConf(args)
   lazy val listApplications =
     opt[Boolean]("list-applications", required = false, descr = "List all applications (operation)")
   lazy val verbose =
-    opt[Boolean]("verbose",
-                 required = false,
-                 descr =
-                   "List addtnl info (aliases and collections) for all applications (operation)")
+    opt[Boolean](
+      "verbose",
+      required = false,
+      descr = "List additional info (aliases and collections) for all applications (operation)")
   verify()
 }

--- a/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRollerCliParser.scala
+++ b/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRollerCliParser.scala
@@ -33,5 +33,10 @@ class CollectionRollerCliArgsParser(args: Seq[String]) extends ScallopConf(args)
     opt[String]("delete-applications", required = false, descr = "Delete applications (operation)")
   lazy val listApplications =
     opt[Boolean]("list-applications", required = false, descr = "List all applications (operation)")
+  lazy val verbose =
+    opt[Boolean]("verbose",
+                 required = false,
+                 descr =
+                   "List addtnl info (aliases and collections) for all applications (operation)")
   verify()
 }

--- a/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRollerMain.scala
+++ b/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRollerMain.scala
@@ -51,6 +51,8 @@ object CollectionRollerMain extends LazyLogging {
       }
     } else if (parsedArgs.deleteApplications.supplied) {
       deleteApplications(parsedArgs)
+    } else if (parsedArgs.listApplications.supplied && parsedArgs.verbose.supplied) {
+      listApplicationsVerbose(parsedArgs)
     } else if (parsedArgs.listApplications.supplied) {
       listApplications(parsedArgs)
     } else {
@@ -79,6 +81,28 @@ object CollectionRollerMain extends LazyLogging {
     val (solr, solrService, collectionRoller) = createServices(parsedArgs)
     try {
       collectionRoller.collectionList().foreach(println)
+
+    } finally {
+      solrService.close()
+      solr.shutdown()
+    }
+    logger.info("Ending Collection Roller List App")
+  }
+
+  private def listApplicationsVerbose(parsedArgs: CollectionRollerCliArgsParser): Unit = {
+    logger.info("Starting Collection Roller List App")
+
+    val (solr, solrService, collectionRoller) = createServices(parsedArgs)
+    try {
+
+      println("Applications:")
+      collectionRoller.collectionList().foreach(println)
+      println("Aliases/Collections:")
+
+      for ((k, v) <- collection.mutable.LinkedHashMap(
+             collectionRoller.aliasMap().toSeq.sortBy(_._1): _*))
+        printf(" Alias : %s  Collection(s) : %s\n", k, v.mkString(","))
+
     } finally {
       solrService.close()
       solr.shutdown()

--- a/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRollerMain.scala
+++ b/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRollerMain.scala
@@ -94,14 +94,18 @@ object CollectionRollerMain extends LazyLogging {
 
     val (solr, solrService, collectionRoller) = createServices(parsedArgs)
     try {
+      for (app <- collectionRoller.collectionList()) {
 
-      println("Applications:")
-      collectionRoller.collectionList().foreach(println)
-      println("Aliases/Collections:")
+        println(app)
 
-      for ((k, v) <- collection.mutable.LinkedHashMap(
-             collectionRoller.aliasMap().toSeq.sortBy(_._1): _*))
-        printf(" Alias : %s  Collection(s) : %s\n", k, v.mkString(","))
+        println("\t" + app + "_latest")
+        for ((k, v) <- collectionRoller.aliasMap().filter(alias => alias._1 == app + "_latest"))
+          println("\t\t" + v.mkString("\n"))
+
+        println("\t" + app + "_all")
+        for ((k, v) <- collectionRoller.aliasMap().filter(alias => alias._1 == app + "_all"))
+          println("\t\t" + v.mkString("\n"))
+      }
 
     } finally {
       solrService.close()

--- a/collection-roller/src/test/scala/io/phdata/pulse/collectionroller/CollectionRollerMainTest.scala
+++ b/collection-roller/src/test/scala/io/phdata/pulse/collectionroller/CollectionRollerMainTest.scala
@@ -48,6 +48,33 @@ class CollectionRollerMainTest extends FunSuite with BaseSolrCloudTest {
     assert(collectionRoller.collectionList().contains(app2Name))
   }
 
+  test("List applications from Main method in verbose mode") {
+    val app1Name = TestUtil.randomIdentifier()
+    val app2Name = TestUtil.randomIdentifier()
+    val args = Array(
+      "--conf",
+      "sample conf",
+      "--zk-hosts",
+      miniSolrCloudCluster.getZkServer.getZkAddress,
+      "--list-applications",
+      "--verbose"
+    )
+
+    val appList = List(
+      Application(app1Name, None, None, None, None, "testconf"),
+      Application(app2Name, None, None, None, None, "testconf")
+    )
+    collectionRoller.initializeApplications(appList)
+    assert(collectionRoller.collectionList().contains(app1Name))
+    assert(collectionRoller.collectionList().contains(app2Name))
+
+    CollectionRollerMain.main(args)
+
+    // check if alias exists for app1 & app2
+    assert(collectionRoller.collectionList().contains(app1Name))
+    assert(collectionRoller.collectionList().contains(app2Name))
+  }
+
   test("delete applications from Main method") {
     val app1Name = TestUtil.randomIdentifier()
     val app2Name = TestUtil.randomIdentifier()


### PR DESCRIPTION
Hi Tony,

For PAMS-142, it prints as

Applications:
d2cce
89b2a
ed94a
f2558
Aliases/Collections:
Alias : 89b2a_all Collection(s) : 89b2a_1529460182
Alias : 89b2a_latest Collection(s) : 89b2a_1529460182
Alias : d2cce_all Collection(s) : d2cce_1529460182
Alias : d2cce_latest Collection(s) : d2cce_1529460182
Alias : ed94a_all Collection(s) : ed94a_1529460182
Alias : ed94a_latest Collection(s) : ed94a_1529460182
Alias : f2558_all Collection(s) : f2558_1529460182
Alias : f2558_latest Collection(s) : f2558_1529460182

when --verbose is specified. Please let me know if this is not what you had in mind. Thanks.