### PR TITLE
Rename 'pulse-logger' to 'pulse-logging'

### DIFF
--- a/cloudera-integration/csd/descriptor/service.sdl
+++ b/cloudera-integration/csd/descriptor/service.sdl
@@ -73,7 +73,7 @@
         }
       ],
       "logging" : {
-        "dir" : "/var/log/pulse",
+        "dir" : "/var/log/pulse-logging",
         "filename" : "log-collector.log",
         "modifiable" : true,
         "configName" : "log.dir",
@@ -135,7 +135,7 @@
         }
       ]},
       "logging" : {
-        "dir" : "/var/log/pulse",
+        "dir" : "/var/log/pulse-logging",
         "filename" : "collection-roller.log",
         "modifiable" : true,
         "configName" : "log.dir",
@@ -249,7 +249,7 @@
         }
       ]},
       "logging" : {
-        "dir" : "/var/log/pulse",
+        "dir" : "/var/log/pulse-logging",
         "filename" : "alert-engine.log",
         "modifiable" : true,
         "configName" : "log.dir",

--- a/cloudera-integration/parcel/meta/alternatives.json
+++ b/cloudera-integration/parcel/meta/alternatives.json
@@ -1,6 +1,6 @@
 {
   "conf": {
-    "destination": "/etc/pulse-logger",
+    "destination": "/etc/pulse-logging",
     "source": "conf",
     "priority": 10,
     "isDirectory": true

--- a/collection-roller/README.md
+++ b/collection-roller/README.md
@@ -27,7 +27,7 @@ A Collection Roller configuration file is written in yaml and will look like:
 
 ```yaml
 
-sorlConfigSetDir: /etc/pulse-logger/solr-configs/ # directory containing one or many solr instancedir configs to be uploaded. The name of the config when uploaded to solr will be the name of the directory
+sorlConfigSetDir: /etc/pulse-logging/solr-configs/ # directory containing one or many solr instancedir configs to be uploaded. The name of the config when uploaded to solr will be the name of the directory
 applications:
 # Config using all defaults
 - name: pulse-test-default

--- a/example-configs/collection-roller/collection-roller.yml
+++ b/example-configs/collection-roller/collection-roller.yml
@@ -1,5 +1,5 @@
 ---
-solrConfigSetDir: /etc/pulse-logger/solr-configs/
+solrConfigSetDir: /etc/pulse-logging/solr-configs/
 applications:
 - name: pulse-test-default
   solrConfigSetName: pulseconfigv2


### PR DESCRIPTION
'Logger' implies a single thing, 'logging' maybe better implies the 'framework'

A little picky possibly...