### PR TITLE
Always flush buffers on an ERROR message

### DIFF
--- a/log-appender/README.md
+++ b/log-appender/README.md
@@ -1,9 +1,11 @@
+
 # Java log appenders
 
 ## Log4j 1.x appenders
 The log4j 1.x http appender will send a post message to the `log-collector` process with the
-contents of your log message.
-
+contents of your log message. The appender will batch messages into groups of 1000 records and will 
+flush when a group is available, 1 second has passed. The appender will always flush all messages
+as soon as an ERROR level message is logged.
 
 ## Special Handling 
 - MDC: Fields stored in the MDC (or Mapped Diagnostic Context) will be added as a top level searchable
@@ -34,7 +36,7 @@ log4j.logger.io.phdata.pulse.shade.org.apache.wire=off
 ```
 
 It's recommended (for now) that the logs be written to file in addition to Pulse through the http 
-appender. Pulse doesn't currently make any availability guarantees.
+appender. This appender currently doesn't currently make any availability guarantees.
 
 Example usage:
 
@@ -57,7 +59,3 @@ client configuration:
 ```bash
 export SPARK_DIST_CLASSPATH="$SPARK_DIST_CLASSPATH:/opt/cloudera/parcels/PULSE/lib/appenders/*"
 ```
-
-
-
-

--- a/log-appender/src/main/java/io/phdata/pulse/log/HttpAppender.java
+++ b/log-appender/src/main/java/io/phdata/pulse/log/HttpAppender.java
@@ -17,6 +17,8 @@
 package io.phdata.pulse.log;
 
 import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.Priority;
 import org.apache.log4j.helpers.LogLog;
 import org.apache.log4j.spi.LoggingEvent;
 
@@ -57,7 +59,7 @@ public class HttpAppender extends AppenderSkeleton {
     try {
       bufferingEventHandler.addEvent(event);
 
-      if (shouldFlush()) {
+      if (shouldFlush(event)) {
         flush();
       }
     } catch (Throwable t) {
@@ -84,12 +86,13 @@ public class HttpAppender extends AppenderSkeleton {
    * If the log messages should be flushed based on previous errors and how many records the batching event handler contains
    * @return Boolean decision
    */
-  private boolean shouldFlush() {
+  private boolean shouldFlush(LoggingEvent event) {
     Long currentTime = currentTimeSeconds();
 
     return (bufferingEventHandler.shouldFlush() // The batch has grown large enough or enought time has passed
             && lastPostSuccess // the last post was a success
-            || currentTime > lastSuccessfulPostTime + backoffTimeSeconds); // enough time has passed after the last failure that we want to try to post again
+            || currentTime > lastSuccessfulPostTime + backoffTimeSeconds // enough time has passed after the last failure that we want to try to post again
+            || event.getLevel().isGreaterOrEqual(Level.ERROR)); // always flush on error messages
   }
 
   @Override

--- a/log-appender/src/test/java/io/phdata/pulse/log/HttpAppenderTest.java
+++ b/log-appender/src/test/java/io/phdata/pulse/log/HttpAppenderTest.java
@@ -83,6 +83,25 @@ public class HttpAppenderTest {
     Mockito.verify(httpManager, times(1)).send(Matchers.any());
   }
 
+  @Test
+  public void flushEventsOnError() {
+    Logger logger = Logger.getLogger("io.phdata.pulse.log.HttpAppenderTest");
+
+    LoggingEvent event = new LoggingEvent("io.phdata.pulse.log.HttpAppenderTest", logger, 1, Level.ERROR, "Hello, World",
+            "main", null, "ndc", null, null);
+
+    Mockito.when(httpManager.send(Matchers.any())).thenReturn(true);
+    HttpAppender appender = new HttpAppender();
+    appender.setBatchingEventHandler(new BufferingEventHandler());
+
+    appender.setHttpManager(httpManager);
+    // first event should call 'send'
+    appender.append(event);
+
+    // verify 'send' was called
+    Mockito.verify(httpManager, times(1)).send(Matchers.any());
+  }
+
 }
 
 /**


### PR DESCRIPTION
There is a JVM Shutdown hook that runs to flush any messages in the
buffer in case of application exit, but this is an extra guarantee that
error messages will be flushed in case of any application issues.