### PR TITLE
Add hostname from log4j appender

### DIFF
--- a/log-appender/src/test/java/io/phdata/pulse/log/HttpAppenderTest.java
+++ b/log-appender/src/test/java/io/phdata/pulse/log/HttpAppenderTest.java
@@ -5,10 +5,7 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.*;
 
 import static org.mockito.Mockito.times;
 
@@ -100,6 +97,27 @@ public class HttpAppenderTest {
 
     // verify 'send' was called
     Mockito.verify(httpManager, times(1)).send(Matchers.any());
+  }
+
+  @Test
+  public void setHostname() {
+    Logger logger = Logger.getLogger("io.phdata.pulse.log.HttpAppenderTest");
+
+    LoggingEvent event = new LoggingEvent("io.phdata.pulse.log.HttpAppenderTest", logger, 1, Level.ERROR, "Hello, World",
+            "main", null, "ndc", null, null);
+
+    ArgumentCaptor<String> sendArgument = ArgumentCaptor.forClass(String.class);
+
+    HttpAppender appender = new HttpAppender();
+    appender.setBatchingEventHandler(new BufferingEventHandler());
+
+    appender.setHttpManager(httpManager);
+    // first event should call 'send' since we are sending an error message
+    appender.append(event);
+
+    Mockito.verify(httpManager).send(sendArgument.capture());
+
+    assert(sendArgument.getValue().contains("\"hostname\":"));
   }
 
 }

--- a/log-example/src/main/scala/io/phdata/pulse/example/SparkLog4jExample.scala
+++ b/log-example/src/main/scala/io/phdata/pulse/example/SparkLog4jExample.scala
@@ -44,8 +44,6 @@ object SparkLog4jExample {
     val applicationId = sc.applicationId
     // set the application id of the driver
     org.apache.log4j.MDC.put("application_id", applicationId)
-    // set the hostname of the driver
-    org.apache.log4j.MDC.put("hostname", InetAddress.getLocalHost().getHostName())
 
     /**
      * This lazy initializer will put the  hostname and application_id on the executors
@@ -54,13 +52,10 @@ object SparkLog4jExample {
      */
     object LoggingConfiguration {
       lazy val init = {
-        setHostName
         setMdcAppId
       }
       private lazy val setMdcAppId = Try(MDC.put("application_id", applicationId))
         .getOrElse(log.warn(s"Error setting application id"))
-      private lazy val setHostName = Try(
-        MDC.put("hostname", InetAddress.getLocalHost().getHostName()))
     }
 
     testRdd.foreach { num =>


### PR DESCRIPTION
Previously adding the hostname could be done manually, but it was a
little tricky, especially for Spark applications.

If the hostname is successfully retrieved it is set in the 'properties'
of the log4j message, which is then created as a dynamic property in the
Solr index. In the future the 'hostname' should be added as a named
field to the Solr 'schema.xml'