### PR TITLE
Added copyField directives to catch-all field 'text'.

### DIFF
--- a/cloudera-integration/parcel/conf/solr-configs/pulseconfigv2/schema.xml
+++ b/cloudera-integration/parcel/conf/solr-configs/pulseconfigv2/schema.xml
@@ -59,6 +59,12 @@
       -->
     <uniqueKey>id</uniqueKey>
 
+    <copyField source="category" dest="text"/>
+    <copyField source="level" dest="text"/>
+    <copyField source="message" dest="text"/>
+    <copyField source="threadName" dest="text"/>
+    <copyField source="throwable" dest="text"/>
+
     <types>
         <!-- field type definitions. The "name" attribute is
            just a label to be used by field definitions.  The "class"

--- a/test-config/solr_configs/conf/schema.xml
+++ b/test-config/solr_configs/conf/schema.xml
@@ -58,6 +58,12 @@
 
     <uniqueKey>id</uniqueKey>
 
+    <copyField source="category" dest="text"/>
+    <copyField source="level" dest="text"/>
+    <copyField source="message" dest="text"/>
+    <copyField source="threadName" dest="text"/>
+    <copyField source="throwable" dest="text"/>
+
     <types>
         <!-- field type definitions. The "name" attribute is
            just a label to be used by field definitions.  The "class"


### PR DESCRIPTION
'text' is already the default search field (specified in solrconfig.xml).

Closes #30 