### PR TITLE
Implement objectmother pattern on all repeated test objects

### DIFF
--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestAlertrules.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestAlertrules.scala
@@ -1,0 +1,99 @@
+
+/*
+ * Copyright 2018 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pulse.alertengine
+
+
+/**
+  * Mother interface/factory for alert rules
+  */
+trait TestAlertrules
+
+/**
+  * Mother object ifor alert rules
+  */
+object TestAlertrules {
+
+  def apply(ruleType: String): AlertRule = {
+    ruleType match {
+      case "defualtWithRetryInterval10" => defaultWithRetryInterval10
+      case "emailWithRetryInterval10" => emailWithRetryInterval10
+      case "slackWithRetryInterval10" => slackWithRetryInterval10
+      case "slackWithRetryInterval20" => slackWithRetryInterval20
+      case "emailWithRetryInterval1" => emailWithRetryInterval1
+      case "emailWithRetryInterval1AndQueryIsNotexists" => emailWithRetryInterval1AndQueryIsNotexists
+      case "emailWithRetryInterval1AndQueryIsId" => emailWithRetryInterval1AndQueryIsId
+      case "emailWithRetryInterval1AndQueryIsSpark1query" => emailWithRetryInterval1AndQueryIsSpark1query
+      case "emailWithRetryInterval1AndQueryIsSpark1query1" => emailWithRetryInterval1AndQueryIsSpark1query1
+      case "emailWithRetryInterval1AndresultThreshold1" => emailWithRetryInterval1AndresultThreshold1
+    }
+  }
+
+  /*
+  *factory methods
+   */
+
+  def defaultWithRetryInterval10: AlertRule = {
+    AlertRule("query0000000000", 10, Some(0), List("a", "slack"))
+
+  }
+
+  def emailWithRetryInterval10: AlertRule = {
+    AlertRule("query0000000000", 10, Some(0), List("a", "email"))
+  }
+
+  def slackWithRetryInterval10: AlertRule = {
+    AlertRule("query0000000000", 10, Some(0), List("a", "slack"))
+
+  }
+
+  def slackWithRetryInterval20: AlertRule = {
+    AlertRule("query0000000000", 20, Some(0), List("a", "slack"))
+
+  }
+
+  def emailWithRetryInterval1: AlertRule = {
+    AlertRule("category: DOESNOTEXIST", 1, Some(-1), List("tony@phdata.io"))
+
+  }
+
+  def emailWithRetryInterval1AndQueryIsNotexists: AlertRule = {
+    AlertRule("id: notexists", 1, Some(0), List("tony@phdata.io"))
+  }
+
+  def emailWithRetryInterval1AndresultThreshold1: AlertRule = {
+    AlertRule("category: DOESNOTEXIST", 1, Some(1), List("tony@phdata.io"))
+  }
+
+  def emailWithRetryInterval1AndQueryIsId: AlertRule = {
+    AlertRule("id: id", 1, Some(0), List("mailprofile1"))
+  }
+
+  def emailWithRetryInterval1AndQueryIsSpark1query: AlertRule = {
+    AlertRule("spark1query", 10, Some(10), List("mailprofile1"))
+  }
+
+  def emailWithRetryInterval1AndQueryIsSpark1query1: AlertRule = {
+    AlertRule("spark2query1", 10, Some(10), List("mailprofile1"))
+  }
+
+  def slackWithRetryInterval1AndQueryIsId: AlertRule = {
+    AlertRule("id: id", 1, Some(0), List("slackProfile1"))
+  }
+
+}
+

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestLogEvents.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestLogEvents.scala
@@ -1,0 +1,65 @@
+
+/*
+ * Copyright 2018 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pulse.alertengine
+
+import io.phdata.pulse.common.domain.LogEvent
+
+
+/**
+  * Mother trait/interface for log events
+  */
+trait TestLogEvents
+
+/**
+  * Mother object for log events
+  */
+object TestLogEvents {
+
+  def apply(categoryAndLevel: String): LogEvent = {
+    categoryAndLevel match {
+      case "alertError" => alertError
+      case "errorError2" => errorError2
+    }
+  }
+
+  /*
+  *Factory methods
+   */
+  def alertError: LogEvent = {
+    LogEvent(Some("id"),
+      "ALERT",
+      "1970-01-01T00:00:00Z",
+      "ERROR",
+      "message",
+      "thread oxb",
+      Some("Exception in thread main"),
+      None)
+  }
+
+  def errorError2: LogEvent = {
+    LogEvent(None,
+      "ERROR",
+      "1972-01-01T22:00:00Z",
+      "ERROR2",
+      "message2",
+      "thread2 oxb",
+      Some("Exception in thread main2"),
+      None)
+  }
+}
+

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestMailAlertProfiles.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestMailAlertProfiles.scala
@@ -1,0 +1,60 @@
+
+/*
+ * Copyright 2018 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pulse.alertengine
+
+/**
+  * Mother trait/interface for Mail Alert Profiles
+  */
+
+trait TestMailAlertProfiles
+
+/**
+  * Mother object for Mail Alert Profiles
+  */
+object TestMailAlertProfiles {
+
+  def apply(category: String): MailAlertProfile = {
+    category match {
+      case "withOneAddress" => withOneAddress
+      case "withTwoAddresses" => withTwoAddresses
+      case "withThreeAddresses" => withThreeAddresses
+      case "withAddressMailProfile1" => withAddressMailProfile1
+    }
+  }
+
+  /*
+  *Factory methods
+   */
+  def withOneAddress: MailAlertProfile = {
+    MailAlertProfile("a", List("testing@phdata.io"))
+  }
+
+  def withTwoAddresses: MailAlertProfile = {
+    MailAlertProfile("b", List("testing1@phdata.io", "testing@phdata.io"))
+  }
+
+  def withThreeAddresses: MailAlertProfile = {
+    MailAlertProfile("b", List("testing1@phdata.io", "testing@phdata.io", "testing@phdata.io"))
+  }
+
+  def withAddressMailProfile1: MailAlertProfile = {
+    MailAlertProfile("mailprofile1", List("person@phdata.io"))
+  }
+
+}
+

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestSolrDocuments.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestSolrDocuments.scala
@@ -1,0 +1,137 @@
+
+/*
+ * Copyright 2018 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pulse.alertengine
+
+
+import org.apache.solr.common.SolrDocument
+
+/**
+  * Mother trait/interface for solr documents
+  */
+trait TestSolrDocuments
+
+/**
+  * Mother object for solr documents
+  */
+object TestSolrDocuments {
+  def apply(category: String): SolrDocument = {
+    category.toUpperCase() match {
+      case "ALL" => all
+      case "DEBUG" => debug
+      case "ERROR" => error
+      case "FATAL" => fatal
+      case "INFO" => info
+      case "OFF" => off
+      case "TRACE" => trace
+      case "WARN" => warn
+    }
+  }
+
+  /*
+*Factory methods
+ */
+  def fatal: SolrDocument = {
+    val doc: SolrDocument = new SolrDocument()
+    doc.addField("id", "123")
+    doc.addField("timestamp", "2018-04-06 10:15:00Z")
+    doc.addField("level", "FATAL")
+    doc.addField("message", "The service is down.")
+    doc.addField("threadName", "thread3")
+    doc.addField("throwable", "NullPointerException")
+    doc
+  }
+
+  def error: SolrDocument = {
+    val doc: SolrDocument = new SolrDocument()
+    doc.addField("id", "123")
+    doc.addField("timestamp", "2018-04-06 10:15:00Z")
+    doc.addField("level", "ERROR")
+    doc.addField("message", "The service is down.")
+    doc.addField("threadName", "thread3")
+    doc.addField("throwable", "NullPointerException")
+    doc
+  }
+
+  def warn: SolrDocument = {
+    val doc: SolrDocument = new SolrDocument()
+    doc.addField("id", "123")
+    doc.addField("timestamp", "2018-04-06 10:15:00Z")
+    doc.addField("level", "WARN")
+    doc.addField("message", "The service is down.")
+    doc.addField("threadName", "thread3")
+    doc.addField("throwable", "NullPointerException")
+    doc
+  }
+
+  def trace: SolrDocument = {
+    val doc: SolrDocument = new SolrDocument()
+    doc.addField("id", "123")
+    doc.addField("timestamp", "2018-04-06 10:15:00Z")
+    doc.addField("level", "TRACE")
+    doc.addField("message", "The service is down.")
+    doc.addField("threadName", "thread3")
+    doc.addField("throwable", "NullPointerException")
+    doc
+  }
+
+  def debug: SolrDocument = {
+    val doc: SolrDocument = new SolrDocument()
+    doc.addField("id", "123")
+    doc.addField("timestamp", "2018-04-06 10:15:00Z")
+    doc.addField("level", "DEBUG")
+    doc.addField("message", "The service is down.")
+    doc.addField("threadName", "thread3")
+    doc.addField("throwable", "NullPointerException")
+    doc
+  }
+
+  def info: SolrDocument = {
+    val doc: SolrDocument = new SolrDocument()
+    doc.addField("id", "123")
+    doc.addField("timestamp", "2018-04-06 10:15:00Z")
+    doc.addField("level", "INFO")
+    doc.addField("message", "The service is down.")
+    doc.addField("threadName", "thread3")
+    doc.addField("throwable", "NullPointerException")
+    doc
+  }
+
+  def all: SolrDocument = {
+    val doc: SolrDocument = new SolrDocument()
+    doc.addField("id", "123")
+    doc.addField("timestamp", "2018-04-06 10:15:00Z")
+    doc.addField("level", "ALL")
+    doc.addField("message", "The service is down.")
+    doc.addField("threadName", "thread3")
+    doc.addField("throwable", "NullPointerException")
+    doc
+  }
+
+  def off: SolrDocument = {
+    val doc: SolrDocument = new SolrDocument()
+    doc.addField("id", "123")
+    doc.addField("timestamp", "2018-04-06 10:15:00Z")
+    doc.addField("level", "OFF")
+    doc.addField("message", "The service is down.")
+    doc.addField("threadName", "thread3")
+    doc.addField("throwable", "NullPointerException")
+    doc
+  }
+
+}
+

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestTriggers.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestTriggers.scala
@@ -1,0 +1,100 @@
+
+/*
+ * Copyright 2018 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pulse.alertengine
+
+/**
+  * Mother trait/interface class for alert Triggers
+  */
+trait TestTriggers
+
+/**
+  * Mother object alert Triggers
+  */
+object TestTriggers {
+
+
+  def apply(triggerType: String): TriggeredAlert = {
+    triggerType match {
+      case "slackWithSparkAppAndTotalNumFound20" => slackWithSparkAppAndTotalNumFound20
+      case "slackWithSparkAppAndTotalNumFound15" => slackWithSparkAppAndTotalNumFound15
+      case "emailWithJavaAppAndTotalNumFound20" => emailWithJavaAppAndTotalNumFound20
+      case "emailWithPythonAppAndTotalNumFound20" => emailWithPythonAppAndTotalNumFound20
+      case "slackWithSparkAppAndTotalNumFound23" => slackWithSparkAppAndTotalNumFound23
+      case "slackWithPipeWrenchAppAndTotalNumFound15" => slackWithPipeWrenchAppAndTotalNumFound15
+      case "slackWithSparkAppAndTotalNumFound12" => slackWithSparkAppAndTotalNumFound12
+      case "slackWithPipeWrenchAppAndTotalNumFound14" => slackWithPipeWrenchAppAndTotalNumFound14
+      case "slackWithSparkAppWithNullDocAndTotalNumFound1" => slackWithSparkAppWithNullDocAndTotalNumFound1
+      // case _                                            => slackWithSparkAppAndTotalNumFound20
+
+    }
+  }
+
+  def slackWithSparkAppAndTotalNumFound20: TriggeredAlert = {
+    val doc = TestSolrDocuments("fatal")
+    val alertrule = TestAlertrules("slackWithRetryInterval10")
+    TriggeredAlert(alertrule, "Spark", Seq(doc), 20)
+  }
+
+  def emailWithJavaAppAndTotalNumFound20: TriggeredAlert = {
+    val doc = TestSolrDocuments("fatal")
+    val alertrule = TestAlertrules("emailWithRetryInterval10")
+    TriggeredAlert(alertrule, "Java", Seq(doc), 20)
+  }
+
+  def emailWithPythonAppAndTotalNumFound20: TriggeredAlert = {
+    val doc = TestSolrDocuments("fatal")
+    val alertrule = TestAlertrules("emailWithRetryInterval10")
+    TriggeredAlert(alertrule, "Python", Seq(doc), 20)
+  }
+
+  def slackWithSparkAppAndTotalNumFound23: TriggeredAlert = {
+    val doc = TestSolrDocuments("fatal")
+    val alertrule = TestAlertrules("slackWithRetryInterval10")
+    TriggeredAlert(alertrule, "Spark", Seq(doc), 23)
+  }
+
+  def slackWithSparkAppWithNullDocAndTotalNumFound1: TriggeredAlert = {
+    val alertrule = TestAlertrules("slackWithRetryInterval10")
+    TriggeredAlert(alertrule, "Spark", null, 1)
+  }
+
+  def slackWithPipeWrenchAppAndTotalNumFound15: TriggeredAlert = {
+    val doc = TestSolrDocuments("fatal")
+    val alertrule = TestAlertrules("slackWithRetryInterval10")
+    TriggeredAlert(alertrule, "Spark", Seq(doc), 15)
+  }
+
+  def slackWithSparkAppAndTotalNumFound12: TriggeredAlert = {
+    val doc = TestSolrDocuments("fatal")
+    val alertrule = TestAlertrules("slackWithRetryInterval10")
+    TriggeredAlert(alertrule, "Spark", Seq(doc), 12)
+  }
+
+  def slackWithSparkAppAndTotalNumFound15: TriggeredAlert = {
+    val doc = TestSolrDocuments("fatal")
+    val alertrule = TestAlertrules("slackWithRetryInterval10")
+    TriggeredAlert(alertrule, "Spark", Seq(doc), 15)
+  }
+
+  def slackWithPipeWrenchAppAndTotalNumFound14: TriggeredAlert = {
+    val doc = TestSolrDocuments("fatal")
+    val alertrule = TestAlertrules("slackWithRetryInterval10")
+    TriggeredAlert(alertrule, "Spark", Seq(doc), 14)
+  }
+
+}

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestTriggers.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestTriggers.scala
@@ -39,8 +39,6 @@ object TestTriggers {
       case "slackWithSparkAppAndTotalNumFound12" => slackWithSparkAppAndTotalNumFound12
       case "slackWithPipeWrenchAppAndTotalNumFound14" => slackWithPipeWrenchAppAndTotalNumFound14
       case "slackWithSparkAppWithNullDocAndTotalNumFound1" => slackWithSparkAppWithNullDocAndTotalNumFound1
-      // case _                                            => slackWithSparkAppAndTotalNumFound20
-
     }
   }
 

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/notification/MailNotificationServiceTest.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/notification/MailNotificationServiceTest.scala
@@ -16,31 +16,23 @@
 
 package io.phdata.pulse.alertengine.notification
 
-import io.phdata.pulse.alertengine.{ AlertRule, MailAlertProfile, TriggeredAlert }
-import org.apache.solr.common.SolrDocument
+import io.phdata.pulse.alertengine._
 import org.scalatest.FunSuite
 
 import scala.io.Source._
 
 class MailNotificationServiceTest extends FunSuite {
 
-  val doc: SolrDocument = new SolrDocument()
-  doc.addField("id", "123")
-  doc.addField("category", "test")
-  doc.addField("timestamp", "2018-04-06 10:15:00Z")
-  doc.addField("level", "FATAL")
-  doc.addField("message", "The service is down.")
-  doc.addField("threadName", "thread3")
-  doc.addField("throwable", "NullPointerException")
+  val doc = TestSolrDocuments("fatal")
 
-  val alertrule  = AlertRule("query0000000000", 10, Some(0), List("a", "slack"))
-  val alertrule2 = AlertRule("query222222", 20, Some(0), List("a", "slack"))
+  val alertrule = TestAlertrules("slackWithRetryInterval10")
+  val alertrule2 = TestAlertrules("slackWithRetryInterval20")
 
-  val profile  = MailAlertProfile("a", List("testing@phdata.io"))
-  val profile2 = MailAlertProfile("b", List("testing1@phdata.io", "testing@phdata.io"))
+  val profile = TestMailAlertProfiles("withOneAddress")
+  val profile2 = TestMailAlertProfiles("withTwoAddresses")
 
-  val triggeredalert  = TriggeredAlert(alertrule, "Spark", Seq(doc), 23)
-  val triggeredalert2 = TriggeredAlert(alertrule2, "PipeWrench", Seq(doc), 15)
+  val triggeredalert = TestTriggers("slackWithSparkAppAndTotalNumFound23")
+  val triggeredalert2 = TestTriggers("slackWithSparkAppAndTotalNumFound15")
 
   test("sending one email to an address") {
     if (new java.io.File("alert-engine/scripts/mail-password.txt").exists) {

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/notification/NotificationFormatterTest.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/notification/NotificationFormatterTest.scala
@@ -16,23 +16,15 @@
 
 package io.phdata.pulse.alertengine.notification
 
-import io.phdata.pulse.alertengine.{ AlertRule, TriggeredAlert }
-import org.apache.solr.common.SolrDocument
+import io.phdata.pulse.alertengine._
 import org.scalatest.FunSuite
 
 class NotificationFormatterTest extends FunSuite {
-  val doc: SolrDocument = new SolrDocument()
-  doc.addField("id", "1970-01-01T00:00:00Z")
-  doc.addField("category", "test")
-  doc.addField("timestamp", "2018-04-06 10:15:00Z")
-  doc.addField("level", "FATAL")
-  doc.addField("message", "The service is down.")
-  doc.addField("threadName", "thread3")
-  doc.addField("throwable", "NullPointerException")
 
-  val alertrule = AlertRule("query0000000000", 10, Some(0), List("a", "slack"))
 
-  val triggeredalert = TriggeredAlert(alertrule, "Spark", Seq(doc), 20)
+  val doc = TestSolrDocuments("fatal")
+  val alertrule = TestAlertrules("slackWithRetryInterval10")
+  val triggeredalert = TestTriggers("slackWithSparkAppAndTotalNumFound20")
 
   test("format subject content") {
     assertResult("Pulse alert triggered for 'Spark'")(

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/notification/SlackNotificationServiceTest.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/notification/SlackNotificationServiceTest.scala
@@ -18,30 +18,23 @@ package io.phdata.pulse.alertengine.notification
 
 import java.io.File
 
-import io.phdata.pulse.alertengine.{ AlertRule, SlackAlertProfile, TriggeredAlert }
-import org.apache.solr.common.SolrDocument
+import io.phdata.pulse.alertengine._
 import org.scalatest.FunSuite
 
 import scala.io.Source.fromFile
 
 class SlackNotificationServiceTest extends FunSuite {
-  val doc: SolrDocument = new SolrDocument()
-  doc.addField("id", "123")
-  doc.addField("category", "test")
-  doc.addField("timestamp", "2018-04-06 10:15:00")
-  doc.addField("level", "FATAL")
-  doc.addField("message", "The service is down.")
-  doc.addField("threadName", "thread3")
-  doc.addField("throwable", "NullPointerException")
+
+  val doc = TestSolrDocuments("fatal")
 
   val path         = "alert-engine/scripts/slack-webhook-url.txt"
   val slackUrlFile = new File(path)
 
-  val alertrule  = AlertRule("query0000000000", 10, Some(0), List("a", "slack"))
-  val alertrule2 = AlertRule("query222222", 20, Some(0), List("a", "slack"))
+  val alertrule = TestAlertrules("slackWithRetryInterval10")
+  val alertrule2 = TestAlertrules("slackWithRetryInterval20")
 
-  val triggeredalert  = TriggeredAlert(alertrule, "Spark", Seq(doc), 12)
-  val triggeredalert2 = TriggeredAlert(alertrule2, "PipeWrench", Seq(doc), 14)
+  val triggeredalert = TestTriggers("slackWithSparkAppAndTotalNumFound12")
+  val triggeredalert2 = TestTriggers("slackWithPipeWrenchAppAndTotalNumFound14")
 
   test("sending a triggered alert to a slack profile") {
     if (slackUrlFile.exists) {


### PR DESCRIPTION
One caveat i noticed while implementing the 'object mother' pattern in our test cases is that the number of factory methods increase in direct proportion with the variation in test objects. This means the 'object mothers'  will keep growing in size as the number of distinct test objects increase.
