### PR TITLE
Error logging capability added to spark logging example

### DIFF
--- a/log-example/src/main/scala/io/phdata/pulse/example/SparkLog4jExample.scala
+++ b/log-example/src/main/scala/io/phdata/pulse/example/SparkLog4jExample.scala
@@ -60,7 +60,9 @@ object SparkLog4jExample {
 
     testRdd.foreach { num =>
       LoggingConfiguration.init // initialized once on first record, value is thrown away an nothing done for other records
-      if (num % 100 == 0) {
+      if (num % 1000 == 0) {
+        log.error(s"XXXXX error! num: " + num)
+      } else if (num % 100 == 0) {
         log.warn(s"XXXXX warning! num: " + num)
       } else {
         log.info(s"XXXXX found: " + num)

--- a/log-example/src/main/scala/io/phdata/pulse/example/SparkLog4jExample.scala
+++ b/log-example/src/main/scala/io/phdata/pulse/example/SparkLog4jExample.scala
@@ -60,9 +60,9 @@ object SparkLog4jExample {
 
     testRdd.foreach { num =>
       LoggingConfiguration.init // initialized once on first record, value is thrown away an nothing done for other records
-      if (num % 1000 == 0) {
+      if (num % 10000 == 0) {
         log.error(s"XXXXX error! num: " + num)
-      } else if (num % 100 == 0) {
+      } else if (num % 5000 == 0) {
         log.warn(s"XXXXX warning! num: " + num)
       } else {
         log.info(s"XXXXX found: " + num)


### PR DESCRIPTION
Previously info and warn logs were generated by spark example and now error logging capability is also added.