### PR TITLE
Require 'solrConfigSetDir'

### DIFF
--- a/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRoller.scala
+++ b/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRoller.scala
@@ -67,6 +67,7 @@ class CollectionRoller(solrService: SolrService, val now: ZonedDateTime)
    * @param solrConfigSetDir Location of the ConfigSetDir
    */
   def uploadConfigsFromDirectory(solrConfigSetDir: String): Try[Unit] = Try {
+    logger.info(s"Uploading Solr config sets from directory $solrConfigSetDir")
     val directory = new File(solrConfigSetDir)
 
     if (!directory.exists()) {
@@ -75,6 +76,10 @@ class CollectionRoller(solrService: SolrService, val now: ZonedDateTime)
 
     val solrInstanceDirectories =
       directory.listFiles.filter(_.isDirectory).toList
+
+    if (solrInstanceDirectories.isEmpty) {
+      logger.warn(s"No solr instance directories found at: $solrConfigSetDir")
+    }
 
     logger.info(s"Attempting to upload directories ${solrInstanceDirectories.mkString(" ")}")
 

--- a/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRollerConfigParser.scala
+++ b/collection-roller/src/main/scala/io/phdata/pulse/collectionroller/CollectionRollerConfigParser.scala
@@ -45,7 +45,7 @@ object ConfigParser {
  * @param solrConfigSetDir Local directory containg one or many Solr Config Sets to be uploaded
  * @param applications List of [[Application]]s
  */
-case class CollectionRollerConfig(solrConfigSetDir: Option[String], applications: List[Application])
+case class CollectionRollerConfig(solrConfigSetDir: String, applications: List[Application])
 
 /**
  *

--- a/collection-roller/src/test/scala/io/phdata/pulse/collectionroller/CollectionRollerTest.scala
+++ b/collection-roller/src/test/scala/io/phdata/pulse/collectionroller/CollectionRollerTest.scala
@@ -16,7 +16,6 @@
 
 package io.phdata.pulse.collectionroller
 
-import java.io.FileNotFoundException
 import java.time.{ ZoneOffset, ZonedDateTime }
 
 import io.phdata.pulse.common.SolrService

--- a/collection-roller/src/test/scala/io/phdata/pulse/collectionroller/ConfigParserTest.scala
+++ b/collection-roller/src/test/scala/io/phdata/pulse/collectionroller/ConfigParserTest.scala
@@ -34,7 +34,7 @@ class ConfigParserTest extends FunSuite {
 
     val expected =
       CollectionRollerConfig(
-        Some("conf"),
+        "conf",
         List(Application("application1", Some(2), Some(1), Some(1), Some(1), "config1")))
 
     assertResult(expected)(ConfigParser.convert(yaml))


### PR DESCRIPTION
It was optional and when not set would not warn (even if there was a
misspelling). Closes #79 