### PR TITLE
Default alert and collection roller configs

### DIFF
--- a/cloudera-integration/csd/aux/alert-engine-default.yml
+++ b/cloudera-integration/csd/aux/alert-engine-default.yml
@@ -1,0 +1,9 @@
+- name: pulse-test-default
+  alertRules:
+  - query: "timestamp:[NOW-10MINUTES TO NOW] AND level: ERROR"
+    retryInterval: 10
+    resultThreshold: 0
+    alertProfiles: mailProfile1
+  emailProfiles:
+  - name: mailProfile1
+    addresses: []

--- a/cloudera-integration/csd/aux/collection-roller-default.yml
+++ b/cloudera-integration/csd/aux/collection-roller-default.yml
@@ -1,0 +1,4 @@
+solrConfigSetDir: /etc/pulse-logging/solr-configs/
+applications:
+- name: pulse-test-default
+  solrConfigSetName: pulseconfigv2

--- a/cloudera-integration/csd/scripts/control.sh
+++ b/cloudera-integration/csd/scripts/control.sh
@@ -39,6 +39,19 @@ export DEFAULT_LOGBACK_CONFIG="${CONF_DIR}/logback.xml" # This is auto-generated
 export LOGBACK_CONFIG=${LOGBACK_CONFIG:-$DEFAULT_LOGBACK_CONFIG}
 export KEYTAB_FILE=${KEYTAB_FILE:-"${CONF_DIR}/pulse.keytab"}
 export AKKA_CONF=${AKKA_CONF:-"application.conf"}
+DEFAULT_COLLECTION_ROLLER_CONFIG=aux/collection-roller-default.yml
+DEFAULT_ALERT_ENGINE_CONFIG=aux/alert-engine-default.yml
+
+# If configs are empty (aren't set in the safety valve) use defaults.
+if [ ! -s "$COLLECTION_ROLLER_CONFIG" ]; then
+    echo "No collection roller config found, using the default."
+    COLLECTION_ROLLER_CONFIG="$DEFAULT_ALERT_ENGINE_CONFIG"
+fi
+
+if [[ ! -s "$ALERT_ENGINE_CONFIG" ]]; then
+    echo "No alert engine config found, using the default."
+    ALERT_ENGINE_CONFIG="$DEFAULT_ALERT_ENGINE_CONFIG"
+fi
 
 export JAAS_CONFIG="Client {
    com.sun.security.auth.module.Krb5LoginModule required

--- a/docs/collection-roller.md
+++ b/docs/collection-roller.md
@@ -28,7 +28,7 @@ A Collection Roller configuration file is written in yaml and will look like:
 
 ```yaml
 
-sorlConfigSetDir: /etc/pulse-logging/solr-configs/ # directory containing one or many solr instancedir configs to be uploaded. The name of the config when uploaded to solr will be the name of the directory
+solrConfigSetDir: /etc/pulse-logging/solr-configs/ # directory containing one or many solr instancedir configs to be uploaded. The name of the config when uploaded to solr will be the name of the directory
 applications:
 # Config using all defaults
 - name: pulse-test-default


### PR DESCRIPTION
Add default configs when running the CM service for the first time.

If the user uses the safety valve or sets the path the default configs
will not be used.

Closes #78 