### PR TITLE
Set default blocking to 'false'

### DIFF
--- a/docs/log-appender.md
+++ b/docs/log-appender.md
@@ -25,6 +25,7 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
 
 log4j.appender.http=io.phdata.pulse.log.HttpAppender
 log4j.appender.http.Address=http://edge2.valhalla.phdata.io:9015/v2/events/pulse-test-100
+log4j.appender.http.blocking=false
 log4j.appender.http.layout=org.apache.log4j.core.layout.JsonLayout
 log4j.appender.http.layout.compact=false
 log4j.appender.http.layout.complete=true
@@ -61,3 +62,9 @@ client configuration:
 ```bash
 export SPARK_DIST_CLASSPATH="$SPARK_DIST_CLASSPATH:/opt/cloudera/parcels/PULSE/lib/appenders/*"
 ```
+
+## Log Appender Options
+
+- `log4j.appender.http.address`: Address of the log collector host.
+- `log4j.appender.http.blocking` (default `false`): Whether the log appender should block if the buffer is full. If the buffer is full and blocking is set to `false` new messages will be dropped.
+- `log4j.appender.http.buffersize` (default `1024`): Default max buffer size.

--- a/log-appender/src/main/java/io/phdata/pulse/log/HttpAppender.java
+++ b/log-appender/src/main/java/io/phdata/pulse/log/HttpAppender.java
@@ -65,7 +65,7 @@ public class HttpAppender extends AppenderSkeleton {
   /**
    * Does appender block when buffer is full.
    */
-  private boolean blocking = true;
+  private boolean blocking = false;
 
   private String hostname = null;
   private Thread dispatcher;


### PR DESCRIPTION
The thought being that it's better to drop messages than affect the
performance of the application. It's already a recommendation that
either console or file appender is used in addition to Pulse.