### PR TITLE
Use text_general less

### DIFF
--- a/cloudera-integration/parcel/conf/solr-configs/pulseconfigv2/schema.xml
+++ b/cloudera-integration/parcel/conf/solr-configs/pulseconfigv2/schema.xml
@@ -21,7 +21,7 @@
     <fields>
         <field name="id" type="string" indexed="true" stored="true" required="true"
                multiValued="false"/>
-        <field name="category" type="text_general" indexed="true" stored="true" required="true"
+        <field name="category" type="string" indexed="true" stored="true" required="true"
                multiValued="false"/>
         <field name="timestamp" type="date" indexed="true" stored="true" required="true"
                multiValued="false"/>
@@ -32,13 +32,13 @@
         <field name="message" type="text_general" indexed="true" stored="true" required="true"
                multiValued="false"/>
 
-        <field name="container_id" type="text_general" indexed="true" stored="true" required="false"
+        <field name="container_id" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
-        <field name="application_id" type="text_general" indexed="true" stored="true" required="false"
+        <field name="application_id" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
-        <field name="threadName" type="text_general" indexed="true" stored="true" required="false"
+        <field name="threadName" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
         <field name="throwable" type="text_general" indexed="true" stored="true" required="false"

--- a/test-config/solr_configs/conf/schema.xml
+++ b/test-config/solr_configs/conf/schema.xml
@@ -21,7 +21,7 @@
     <fields>
         <field name="id" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
-        <field name="category" type="text_general" indexed="true" stored="true" required="true"
+        <field name="category" type="string" indexed="true" stored="true" required="true"
                multiValued="false"/>
         <field name="timestamp" type="date" indexed="true" stored="true" required="true"
                multiValued="false"/>
@@ -35,10 +35,10 @@
         <field name="threadName" type="text_general" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
-        <field name="container_id" type="text_general" indexed="true" stored="true" required="false"
+        <field name="container_id" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
-        <field name="application_id" type="text_general" indexed="true" stored="true" required="false"
+        <field name="application_id" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
         <field name="throwable" type="text_general" indexed="true" stored="true" required="true"


### PR DESCRIPTION
text_general uses solr.TextField, which doesn't support stats and is
causing errors when stats are pulled for that field. Fields aren't long
should work fine as strings.

closes #90