### PR TITLE
Flush the appender on shutdown

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -165,8 +165,8 @@ lazy val `log-example` = project
   .settings(
     name := "log-example",
     settings,
-    libraryDependencies ++= Seq("log4j" % "log4j" % "1.2.16", dependencies.spark)
-  )
+    libraryDependencies ++= Seq("log4j" % "log4j" % "1.2.16", dependencies.spark, dependencies.scalaTest)
+  ).dependsOn(`log-appender`)
 
 // Library versions
 val logbackVersion = "1.2.3"

--- a/log-appender/src/main/java/io/phdata/pulse/log/HttpAppender.java
+++ b/log-appender/src/main/java/io/phdata/pulse/log/HttpAppender.java
@@ -82,6 +82,21 @@ public class HttpAppender extends AppenderSkeleton {
         this.applicationId = Util.getApplicationId();
         this.containerId = Util.getContainerId();
     }
+
+    try {
+      // Shutdown hook will flush log buffers
+      Runtime.getRuntime().addShutdownHook(new Thread()
+      {
+        public void run()
+        {
+          LogLog.debug("HttpAppender shutdown hook called");
+          HttpAppender.this.close();
+          LogLog.debug("HttpAppender shutdown hook finished");
+        }
+      });
+    } catch(Exception e) {
+      LogLog.debug("Failed to add HttpAppender shutdown hook", e);
+    }
   }
 
   /**

--- a/log-example/src/main/scala/io/phdata/pulse/example/SparkLog4jExample.scala
+++ b/log-example/src/main/scala/io/phdata/pulse/example/SparkLog4jExample.scala
@@ -16,11 +16,8 @@
 
 package io.phdata.pams.example
 
-import java.net.InetAddress
-import org.apache.log4j.MDC
 import org.apache.spark.{ SparkConf, SparkContext }
 import org.slf4j.LoggerFactory
-import scala.util.Try
 
 /**
  * This example shows how to
@@ -37,7 +34,15 @@ object SparkLog4jExample {
     val conf = new SparkConf().setAppName("Pulse Spark Logging Example")
     val sc   = SparkContext.getOrCreate(conf)
 
-    val testData = 1 to 1000000
+    try {
+      run(sc, numEvents = 10000)
+    } finally {
+      sc.stop()
+    }
+  }
+
+  def run(sc: SparkContext, numEvents: Int): Unit = {
+    val testData = 1 to numEvents
     val testRdd  = sc.parallelize(testData)
 
     testRdd.foreach { num =>
@@ -51,7 +56,6 @@ object SparkLog4jExample {
     }
 
     log.info("Shutting down the spark logging example")
-    sc.stop()
   }
 
 }

--- a/log-example/src/main/scala/io/phdata/pulse/example/StandaloneAppExample.scala
+++ b/log-example/src/main/scala/io/phdata/pulse/example/StandaloneAppExample.scala
@@ -16,7 +16,8 @@
 
 package io.phdata.pulse.example
 
-import org.apache.log4j.{ Logger, MDC, NDC }
+import javax.naming.NamingException
+import org.apache.log4j.{Logger, MDC, NDC}
 
 object StandaloneAppExample {
   private val log = Logger.getLogger(this.getClass)
@@ -34,7 +35,9 @@ object StandaloneAppExample {
         log.error(s"error happened $uuid", new Exception())
       }
     }
-    throw new Exception("exiting")
+    // Throw an exception so when we turn on `log4j.debug=true` we can see where events stop posting to the log collector
+    // it's a <code>NamingException</code> so we can catch it in the test for this class
+    throw new NamingException("exiting")
 
   }
 

--- a/log-example/src/test/scala/io/phdata/pams/example/SparkLog4jExampleTest.scala
+++ b/log-example/src/test/scala/io/phdata/pams/example/SparkLog4jExampleTest.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pams.example
+
+import org.apache.spark.{ SparkConf, SparkContext }
+import org.scalatest.FunSuite
+
+class SparkLog4jExampleTest extends FunSuite {
+  // TODO fix error: "com.fasterxml.jackson.databind.JsonMappingException: Incompatible Jackson version: 2.9.4"
+  // Can be fixed temporarily by setting the jackson version to '2.2.3', but this needs to be fully tested with the rest of the app
+  ignore("Run test job") {
+    val conf = new SparkConf().setMaster("local[*]").setAppName("Pulse Spark Logging Example")
+    val sc   = SparkContext.getOrCreate(conf)
+
+    SparkLog4jExample.run(sc, 1)
+
+    sc.stop()
+
+  }
+}

--- a/log-example/src/test/scala/io/phdata/pams/example/StandaloneAppExampleTest.scala
+++ b/log-example/src/test/scala/io/phdata/pams/example/StandaloneAppExampleTest.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pams.example
+
+import io.phdata.pulse.example.StandaloneAppExample
+import javax.naming.NamingException
+import org.scalatest.FunSuite
+
+class StandaloneAppExampleTest extends FunSuite {
+  test("Run standalone example") {
+    try {
+      StandaloneAppExample.main(Array("1", "1"))
+    } catch {
+      case e: NamingException =>
+    }
+  }
+}


### PR DESCRIPTION
This commit adds a JVM hook to flush the HttpAppender on shutdown. If
the appender is not flushed, messages can be left in the buffer and
lost.

Closes #94 
