### PR TITLE
PULSE-212

### DIFF
--- a/alert-engine/src/main/scala/io/phdata/pulse/alertengine/AlertEngineMain.scala
+++ b/alert-engine/src/main/scala/io/phdata/pulse/alertengine/AlertEngineMain.scala
@@ -44,13 +44,38 @@ object AlertEngineMain extends LazyLogging {
 
     val executorService = Executors.newSingleThreadScheduledExecutor()
 
+    val solrServer = new CloudSolrServer(parsedArgs.zkHost())
+
+    val mailNotificationService =
+      new MailNotificationService(parsedArgs.smtpServer(),
+                                  parsedArgs.smtpPort(),
+                                  parsedArgs.smtpUser(),
+                                  parsedArgs.smtpPassword,
+                                  parsedArgs.smtp_tls())
+
+    val slackNotificationService = new SlackNotificationService
+
+    val notificationFactory =
+      new NotificationServices(mailNotificationService, slackNotificationService)
+
+    val config = try {
+      AlertEngineConfigParser.getConfig(parsedArgs.conf())
+    } catch {
+      case e: Exception =>
+        logger.error("Error parsing configuration, exiting", e)
+        throw e
+    }
+    logger.info(s"using config: $config")
+    validateConfig(config)
+
     if (parsedArgs.daemonize()) {
       try {
 
-        val scheduledFuture = executorService.scheduleAtFixedRate(new AlertEngineTask(parsedArgs),
-                                                                  0L,
-                                                                  DAEMON_INTERVAL_MINUTES,
-                                                                  TimeUnit.MINUTES)
+        val scheduledFuture = executorService.scheduleAtFixedRate(
+          new AlertEngineTask(solrServer, notificationFactory, config, parsedArgs),
+          0L,
+          DAEMON_INTERVAL_MINUTES,
+          TimeUnit.MINUTES)
         Runtime.getRuntime.addShutdownHook(shutDownHook(scheduledFuture))
         executorService.awaitTermination(Long.MaxValue, TimeUnit.DAYS)
       } catch {
@@ -59,7 +84,7 @@ object AlertEngineMain extends LazyLogging {
         executorService.shutdown()
       }
     } else {
-      val alertTask = new AlertEngineTask(parsedArgs)
+      val alertTask = new AlertEngineTask(solrServer, notificationFactory, config, parsedArgs)
       alertTask.run()
     }
 
@@ -104,40 +129,19 @@ object AlertEngineMain extends LazyLogging {
    * Task for running an alert. Can be schduled to be run repeatedly.
    * @param parsedArgs Application arguments
    */
-  class AlertEngineTask(parsedArgs: AlertEngineCliParser) extends Runnable {
+  class AlertEngineTask(solrServer: CloudSolrServer,
+                        notificationFactory: NotificationServices,
+                        config: AlertEngineConfig,
+                        parsedArgs: AlertEngineCliParser)
+      extends Runnable {
 
     override def run(): Unit = {
       logger.info("starting Alerting Engine run")
-      val config = try {
-        AlertEngineConfigParser.getConfig(parsedArgs.conf())
-      } catch {
-        case e: Exception =>
-          logger.info("Error parsing configuration, exiting", e)
-          System.exit(1)
-          throw new RuntimeException(e) // this code won't be reached but is needed for the typechecker
-      }
-
-      logger.info(s"using config: $config")
-      validateConfig(config)
-
-      val solrServer = new CloudSolrServer(parsedArgs.zkHost())
-
-      logger.info("starting Alert Engine run")
-      val mailNotificationService =
-        new MailNotificationService(parsedArgs.smtpServer(),
-                                    parsedArgs.smtpPort(),
-                                    parsedArgs.smtpUser(),
-                                    parsedArgs.smtpPassword,
-                                    parsedArgs.smtp_tls())
-
-      val slackNotificationService = new SlackNotificationService
 
       val silencedApplications = parsedArgs.silencedApplicationsFile
         .map(file => readSilencedApplications(file))
         .getOrElse(List())
 
-      val notificationFactory =
-        new NotificationServices(mailNotificationService, slackNotificationService)
       try {
         val engine: AlertEngine = new AlertEngineImpl(solrServer, notificationFactory)
         engine.run(config.applications, silencedApplications)
@@ -145,14 +149,8 @@ object AlertEngineMain extends LazyLogging {
       } catch {
         case e: Throwable =>
           logger.error("caught exception in AlertEngine task", e)
-          System.exit(1)
-      } finally {
-        try {
-          solrServer.shutdown()
-        } catch {
-          case e: Exception => logger.warn("exception closing solr server", e)
-        }
       }
+
     }
   }
 }


### PR DESCRIPTION
Moved the creation of the following from AlertEngineTask to AlertEngineMain:

  - solrServer
  - mailNotificationService
  - slackNotificationService
  - notificationFactory
  - config

AlertEngineTask takes solrServer, notificationFactory, and config as parameters.

Removed automatic closing of solrServer after a AlertEngineTask run.

Fixed log level for "Error running AlertEngineMain".