### PR TITLE
Allow lower casing of buffersize paramenter

### DIFF
--- a/log-appender/src/main/java/io/phdata/pulse/log/HttpAppender.java
+++ b/log-appender/src/main/java/io/phdata/pulse/log/HttpAppender.java
@@ -233,6 +233,18 @@ public class HttpAppender extends AppenderSkeleton {
   }
 
   /**
+   * Force bufferSize to be at least 1.
+   *
+   * @param size must be greater than zero
+   */
+  public void setbuffersize(int size) {
+    synchronized (buffer) {
+      this.bufferSize = (size < 1) ? 1 : size;
+      buffer.notifyAll();
+    }
+  }
+
+  /**
    * Determine if the appender should block when the buffer is full. Default value is true.
    *
    * @param blocking boolean

--- a/log-appender/src/test/resources/log4j.properties
+++ b/log-appender/src/test/resources/log4j.properties
@@ -2,5 +2,4 @@ log4j.rootLogger=info, stdout, http
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%5p [%t] %c - %m%n
-
 log4j.debug=true


### PR DESCRIPTION
Log4j will allower lowercasing of the first letter so the valid params
for setting the buffer size are 'bufferSize' or 'BufferSize'. This adds
'buffersize' as a valid key.