### PR TITLE
New JSON Endpoint & refactor to use Map[String,String] instead of LogEvent

### DIFF
--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/AlertEngineImplTest.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/AlertEngineImplTest.scala
@@ -26,6 +26,7 @@ import io.phdata.pulse.alertengine.notification.{
 import io.phdata.pulse.common.{ DocumentConversion, SolrService }
 import io.phdata.pulse.testcommon.{ BaseSolrCloudTest, TestUtil }
 import org.apache.solr.client.solrj.impl.CloudSolrServer
+import org.apache.solr.common.SolrInputDocument
 import org.mockito.Mockito
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ BeforeAndAfterEach, FunSuite }
@@ -64,15 +65,23 @@ class AlertEngineImplTest
     solrClient.setDefaultCollection(alias)
     val result = solrService.createCollection(alias, 1, 1, CONF_NAME, null)
 
-    val document = DocumentConversion.toSolrDocument(TestObjectGenerator.logEvent())
-    val documentError = DocumentConversion.toSolrDocument(
-      TestObjectGenerator.logEvent(id = None,
-                                   category = "ERROR",
-                                   level = "ERROR2",
-                                   message = "message2",
-                                   throwable = Some("Exception in thread main")))
+    val document = DocumentConversion.mapToSolrDocument(
+      Map(
+        "id"         -> "123",
+        "category"   -> "test",
+        "timestamp"  -> "2018-04-06 10:15:00",
+        "level"      -> "FATAL",
+        "message"    -> "The service is down.",
+        "threadName" -> "thread3",
+        "throwable"  -> "NullPointerException"
+      ))
 
-    solrClient.add(document)
+    val documentError = DocumentConversion.mapToSolrDocument(
+      Map("category"  -> "ERROR",
+          "timestamp" -> "1970-01-01T00:00:00Z",
+          "level"     -> "ERROR2",
+          "message"   -> "message2",
+          "throwable" -> "Exception in thread main"))
 
     for (i <- 1 to 12) {
       solrClient.add(documentError)

--- a/cloudera-integration/parcel/conf/solr-configs/pulseconfig-securev1/schema.xml
+++ b/cloudera-integration/parcel/conf/solr-configs/pulseconfig-securev1/schema.xml
@@ -21,18 +21,18 @@
     <fields>
         <field name="id" type="string" indexed="true" stored="true" required="true"
                multiValued="false"/>
-        <field name="category" type="string" indexed="true" stored="true" required="true"
+        <field name="category" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
-        <field name="timestamp" type="date" indexed="true" stored="true" required="true"
+        <field name="timestamp" type="date" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
-        <field name="level" type="string" indexed="true" stored="true" required="true"
+        <field name="level" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
         <field name="hostname" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
-        <field name="message" type="text_general" indexed="true" stored="true" required="true"
+        <field name="message" type="text_general" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
         <field name="container_id" type="string" indexed="true" stored="true" required="false"

--- a/cloudera-integration/parcel/conf/solr-configs/pulseconfigv2/schema.xml
+++ b/cloudera-integration/parcel/conf/solr-configs/pulseconfigv2/schema.xml
@@ -21,18 +21,18 @@
     <fields>
         <field name="id" type="string" indexed="true" stored="true" required="true"
                multiValued="false"/>
-        <field name="category" type="string" indexed="true" stored="true" required="true"
+        <field name="category" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
-        <field name="timestamp" type="date" indexed="true" stored="true" required="true"
+        <field name="timestamp" type="date" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
-        <field name="level" type="string" indexed="true" stored="true" required="true"
+        <field name="level" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
         <field name="hostname" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
-        <field name="message" type="text_general" indexed="true" stored="true" required="true"
+        <field name="message" type="text_general" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
         <field name="container_id" type="string" indexed="true" stored="true" required="false"

--- a/common/src/main/scala/io/phdata/pulse/common/DocumentConversion.scala
+++ b/common/src/main/scala/io/phdata/pulse/common/DocumentConversion.scala
@@ -24,24 +24,14 @@ import org.apache.solr.common.{ SolrDocument, SolrInputDocument }
  */
 object DocumentConversion {
 
-  def toSolrDocument(event: LogEvent): SolrInputDocument = {
+  /**
+   * Convert a [[Map[String, String]]] to a [[SolrInputDocument]]
+   * @param event [[Map[String, String]]] to convert
+   * @return The document as a [[SolrDocument]]
+   */
+  def mapToSolrDocument(event: Map[String, String]): SolrInputDocument = {
     val doc = new SolrInputDocument()
-    event.id.foreach(id => doc.addField("id", id))
-    doc.addField("category", event.category)
-    doc.addField("timestamp", event.timestamp)
-    doc.addField("level", event.level)
-    doc.addField("message", event.message)
-    doc.addField("threadName", event.threadName)
-    doc.addField("throwable", event.throwable.getOrElse(""))
-
-    // If the event properties exist, add each property to the document. The fields will be added as
-    // dynamic [[String]] fields
-    event.properties.fold() { properties =>
-      properties.foreach {
-        case (k: String, v: String) =>
-          doc.addField(s"$k", v)
-      }
-    }
+    event.foreach(field => doc.addField(field._1, field._2))
     doc
   }
 

--- a/common/src/test/scala/io/phdata/pulse/common/SolrServiceTest.scala
+++ b/common/src/test/scala/io/phdata/pulse/common/SolrServiceTest.scala
@@ -18,7 +18,6 @@ package io.phdata.pulse.common
 
 import java.io.File
 
-import io.phdata.pulse.common.domain.LogEvent
 import io.phdata.pulse.testcommon.{ BaseSolrCloudTest, TestUtil }
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.common.util.NamedList
@@ -132,25 +131,25 @@ class SolrServiceTest extends FunSuite with BaseSolrCloudTest {
     val collectionName = TestUtil.randomIdentifier()
     solrService.createCollection(collectionName, 1, 1, "testconf", null)
 
-    val document1 = DocumentConversion.toSolrDocument(
-      new LogEvent(None,
-                   "ERROR",
-                   "1970-01-01T00:00:00Z",
-                   "ERROR",
-                   "message",
-                   "thread oxb",
-                   Some("Exception in thread main"),
-                   None))
+    val document1 = DocumentConversion.mapToSolrDocument(
+      Map(
+        "category"   -> "ERROR",
+        "timestamp"  -> "1970-01-01T00:00:00Z",
+        "level"      -> "ERROR",
+        "message"    -> "message",
+        "threadName" -> "thread oxb",
+        "throwable"  -> "Exception in thread main"
+      ))
 
-    val document2 = DocumentConversion.toSolrDocument(
-      new LogEvent(None,
-                   "ERROR",
-                   "1970-01-01T00:00:00Z",
-                   "ERROR",
-                   "message",
-                   "thread oxb",
-                   Some("Exception in thread main"),
-                   None))
+    val document2 = DocumentConversion.mapToSolrDocument(
+      Map(
+        "category"   -> "ERROR",
+        "timestamp"  -> "1970-01-01T00:00:00Z",
+        "level"      -> "ERROR",
+        "message"    -> "message",
+        "threadName" -> "thread oxb",
+        "throwable"  -> "Exception in thread main"
+      ))
 
     solrService.insertDocuments(collectionName, Seq(document1, document2))
 
@@ -167,17 +166,16 @@ class SolrServiceTest extends FunSuite with BaseSolrCloudTest {
     val collectionName = TestUtil.randomIdentifier()
     solrService.createCollection(collectionName, 1, 1, "testconf", null)
 
-    val properties = Map("hostname" -> "host1.com")
-
-    val document1 = DocumentConversion.toSolrDocument(
-      new LogEvent(None,
-                   "ERROR",
-                   "1970-01-01T00:00:00Z",
-                   "ERROR",
-                   "message",
-                   "thread oxb",
-                   Some("Exception in thread main"),
-                   Some(properties)))
+    val document1 = DocumentConversion.mapToSolrDocument(
+      Map(
+        "category"   -> "ERROR",
+        "timestamp"  -> "1970-01-01T00:00:00Z",
+        "level"      -> "ERROR",
+        "message"    -> "message",
+        "threadName" -> "thread oxb",
+        "throwable"  -> "Exception in thread main",
+        "hostname"   -> "host1.com"
+      ))
 
     solrService.insertDocuments(collectionName, Seq(document1))
 

--- a/log-collector/src/main/scala/io/phdata/pulse/logcollector/PulseKafkaConsumer.scala
+++ b/log-collector/src/main/scala/io/phdata/pulse/logcollector/PulseKafkaConsumer.scala
@@ -53,11 +53,9 @@ class PulseKafkaConsumer(solrService: SolrService) extends JsonSupport with Lazy
         val records = consumer.poll(MAX_TIMEOUT)
         for (record <- records.asScala) {
           logger.trace("KAFKA: Consuming " + record.value() + " from topic: " + topic)
-          val logEvent = record
-            .value()
-            .parseJson
-            .convertTo[LogEvent]
-          solrInputStream ! (logEvent.application.get, logEvent)
+          val logEvent    = record.value().parseJson.convertTo[LogEvent]
+          val logEventMap = Util.logEventToFlattenedMap(logEvent)
+          solrInputStream ! (logEventMap.getOrElse("application", None), logEventMap)
         }
       } catch {
         case p: ParsingException => logger.error("Error parsing message from kafka broker", p)

--- a/log-collector/src/main/scala/io/phdata/pulse/logcollector/Util.scala
+++ b/log-collector/src/main/scala/io/phdata/pulse/logcollector/Util.scala
@@ -1,0 +1,29 @@
+package io.phdata.pulse.logcollector
+
+import io.phdata.pulse.common.domain.LogEvent
+
+object Util {
+
+  /**
+   * Convert a [[LogEvent]] to [[Map[String,String]] by flattening the nested properties field
+   * @param logEvent LogEvent to convert
+   * @return The event, with properties flattened, as a [[Map[String,String]]
+   */
+  def logEventToFlattenedMap(logEvent: LogEvent): Map[String, String] = {
+    val rawMap = Map(
+      "id"          -> logEvent.id.getOrElse(""),
+      "category"    -> logEvent.category,
+      "timestamp"   -> logEvent.timestamp,
+      "level"       -> logEvent.level,
+      "message"     -> logEvent.message,
+      "threadName"  -> logEvent.threadName,
+      "throwable"   -> logEvent.throwable.getOrElse(""),
+      "application" -> logEvent.application.getOrElse("")
+    )
+
+    logEvent.properties match {
+      case Some(properties) => rawMap ++ properties
+      case None             => rawMap
+    }
+  }
+}

--- a/log-collector/src/test/scala/io/phdata/pulse/logcollector/LogCollectorRoutesTest.scala
+++ b/log-collector/src/test/scala/io/phdata/pulse/logcollector/LogCollectorRoutesTest.scala
@@ -47,6 +47,24 @@ class LogCollectorRoutesTest
                               Some("Exception in thread main"),
                               None)
 
+  val jsonArrayDocument: String =
+    """[
+      |{ "timestamp": "1970-01-01T00:00:00Z",
+      | "category": "ERROR",
+      | "message": "message",
+      | "threadName": "thread oxb",
+      | "throwable": "Exception in thread main",
+      | "level": "ERROR"
+      | },
+      | { "timestamp": "1970-01-01T00:00:00Z",
+      | "category": "ERROR",
+      | "message": "message",
+      | "threadName": "thread oxb",
+      | "throwable": "Exception in thread main",
+      | "level": "ERROR"
+      | }
+      | ]""".stripMargin
+
   val solrService = new SolrService(miniSolrCloudCluster.getZkServer.getZkAddress, solrClient)
 
   solrService.uploadConfDir(
@@ -80,6 +98,15 @@ class LogCollectorRoutesTest
 
     Post(uri = "/v2/events/test")
       .withEntity(entity) ~> Route.seal(routes) ~> check {
+      assert(status === (StatusCodes.OK))
+    }
+  }
+
+  test("post json array to 'json' endpoint") {
+    val docEntity = Marshal(jsonArrayDocument).to[MessageEntity].futureValue
+
+    Post(uri = "/v1/json/test")
+      .withEntity(docEntity) ~> routes ~> check {
       assert(status === (StatusCodes.OK))
     }
   }

--- a/log-collector/src/test/scala/io/phdata/pulse/logcollector/SolrCloudStreamsTest.scala
+++ b/log-collector/src/test/scala/io/phdata/pulse/logcollector/SolrCloudStreamsTest.scala
@@ -105,7 +105,8 @@ class SolrCloudStreamsTest extends FunSuite with BaseSolrCloudTest {
     solrService.createCollection(collection, 1, 1, TEST_CONF_NAME, null)
     solrService.createAlias(alias, collection)
 
-    val testValues = List.fill(streamProcessor.DEFALUT_GROUP_SIZE + 100)((app1Name, document1))
+    val testValues = List.fill(streamProcessor.DEFALUT_GROUP_SIZE + 100)(
+      (app1Name, Util.logEventToFlattenedMap(document1)))
 
     val solrStream = streamProcessor.groupedInsert.run()
 

--- a/log-collector/src/test/scala/io/phdata/pulse/logcollector/UtilTest.scala
+++ b/log-collector/src/test/scala/io/phdata/pulse/logcollector/UtilTest.scala
@@ -1,0 +1,42 @@
+package io.phdata.pulse.logcollector
+
+import io.phdata.pulse.common.domain.LogEvent
+import org.scalatest.FunSuite
+
+class UtilTest extends FunSuite {
+
+  val document1 = new LogEvent(None,
+                               "ERROR",
+                               "1970-01-01T00:00:00Z",
+                               "ERROR",
+                               "message 1",
+                               "thread oxb",
+                               Some("Exception in thread main"),
+                               None)
+
+  val document2 = new LogEvent(None,
+                              "ERROR",
+                              "1970-01-01T00:00:00Z",
+                              "ERROR",
+                              "message 1",
+                              "thread oxb",
+                              Some("Exception in thread main"),
+                              Some(Map("property1" -> "15", "property2" -> "true")),
+                              None)
+
+  test("Test Util.logEventToFlattenedMap converts LogEvent to Map[String, String]") {
+
+    val parsedLogEventMap = Util.logEventToFlattenedMap(document1)
+
+    assert(parsedLogEventMap.isInstanceOf[Map[String, String]])
+
+  }
+
+  test("Test Util.logEventToFlattenedMap converts LogEvent with properties to Map[String, String]") {
+
+    val parsedLogEventMap = Util.logEventToFlattenedMap(document2)
+
+    assert(parsedLogEventMap.isInstanceOf[Map[String, String]])
+
+  }
+}

--- a/test-config/solr_configs/conf/schema.xml
+++ b/test-config/solr_configs/conf/schema.xml
@@ -19,20 +19,20 @@
 <schema name="pulse" version="1.0">
 
     <fields>
-        <field name="id" type="string" indexed="true" stored="true" required="false"
+        <field name="id" type="string" indexed="true" stored="true" required="true"
                multiValued="false"/>
-        <field name="category" type="string" indexed="true" stored="true" required="true"
+        <field name="category" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
-        <field name="timestamp" type="date" indexed="true" stored="true" required="true"
+        <field name="timestamp" type="date" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
-        <field name="level" type="string" indexed="true" stored="true" required="true"
+        <field name="level" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
         <field name="hostname" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
-        <field name="message" type="text_general" indexed="true" stored="true" required="true"
+        <field name="message" type="text_general" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
         <field name="threadName" type="text_general" indexed="true" stored="true" required="false"
@@ -44,7 +44,7 @@
         <field name="application_id" type="string" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
-        <field name="throwable" type="text_general" indexed="true" stored="true" required="true"
+        <field name="throwable" type="text_general" indexed="true" stored="true" required="false"
                multiValued="false"/>
 
         <field name="text" type="text_general" indexed="true" stored="false" multiValued="true"/>


### PR DESCRIPTION
* LogCollectorRoutes
    * New endpoint that parses JSON Array into Array[Map[String,String]], then sends each Map to the stream
* LogCollectorRoutesTest:
    * test that takes a JSON and runs it through the new route
* Added Util Object:
    * A function logEventToFlattenedMap to convert & flatten LogEvent to Map[String, String]
* Added UtilTest:
    * UtilTest tests the function in Util logEventToFlattenedMap on a LogEvent
    * UtilTest tests the function in Util logEventToFlattenedMap on a LogEvent with properties
* SolrCloudStreams:
    * now takes Map[String,String]
* SolrCloudStreamsTest:
    * test that takes Map[String,String] doc and writes to the collection, asserting that the doc count is greater than 0
* DocumentConversion:
    * Added a function to convert Map[String,String] to SolrDocument
* AlertEngineImplTest & SolrServiceTest:
    * Update to not use DocumentConversion.toSolrDocument, use DocumentConversion.mapToSolrDocument instead
* PulseKafkaConsumer:
    * Incorporated logEventToFlattenedMap
* Schema.xml, secure Schema.xml, test Schema.xml:
    * Changed all required fields except id to required=false. 
    