### PR TITLE
Set explicity JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 scala:
   - 2.11.8
+jdk: openjdk8
 env:
   SBT_OPTS="-Xmx4096M"
 script:


### PR DESCRIPTION
Workaround for `WARNING: An illegal reflective access operation has
occurred`. I think what's happened is that travis has increased the
default version to JDK 9 in their scala images