### PR TITLE
Fix argument for heap size

### DIFF
--- a/cloudera-integration/csd/descriptor/service.sdl
+++ b/cloudera-integration/csd/descriptor/service.sdl
@@ -150,7 +150,7 @@
         ],
         "environmentVariables": {
           "KAFKA_TOPIC": "${topic}",
-          "LOG_COLLECTOR_MAX_HEAP": "${log.collector.max.heap.size}",
+          "LOG_COLLECTOR_MAX_HEAP": "${log.collector.kafka.max.heap.size}",
           "LOG_COLLECTOR_EXTRA_OPTS": "${log.collector.extra.opts}"
         }
       },


### PR DESCRIPTION
The heap size argument for the standard log collector was being used for
the kafka log collector