### PR TITLE
Add support for SQL alert triggers

### DIFF
--- a/alert-engine/src/main/scala/io/phdata/pulse/alertengine/AlertEngineCliParser.scala
+++ b/alert-engine/src/main/scala/io/phdata/pulse/alertengine/AlertEngineCliParser.scala
@@ -45,14 +45,26 @@ class AlertEngineCliParser(args: Seq[String]) extends ScallopConf(args) {
     "smtp-tls",
     required = false,
     descr = "Whether to use START_TLS. Defaults to false")
-  lazy val zkHost: ScallopOption[String] = opt[String](
-    "zk-hosts",
-    required = true,
-    descr = "Zookeeper hosts. Used to connect to Solr Cloud")
   lazy val silencedApplicationsFile: ScallopOption[String] = opt[String](
     "silenced-application-file",
     required = false,
     descr = "File containing applications ignore when alerting, one application per line")
+
+  lazy val zkHost: ScallopOption[String] = opt[String](
+    "zk-hosts",
+    required = false,
+    descr = "Zookeeper hosts. Used to connect to Solr Cloud")
+
+  lazy val dbUrl: ScallopOption[String] =
+    opt[String]("db-url", required = false, descr = "URL to connect to the database")
+  lazy val dbUser: ScallopOption[String] =
+    opt[String]("db-user", required = false, descr = "User to connect to the database as")
+  lazy val dbPassword: ScallopOption[String] =
+    opt[String]("db-password", required = false, descr = "Password to connect to the database with")
+  lazy val dbOptions: ScallopOption[String] = opt[String](
+    "db-options",
+    required = false,
+    descr = "Database connection options in the form `key1=value1;key2=value2`")
 
   verify()
 }

--- a/alert-engine/src/main/scala/io/phdata/pulse/alertengine/notification/SlackNotificationService.scala
+++ b/alert-engine/src/main/scala/io/phdata/pulse/alertengine/notification/SlackNotificationService.scala
@@ -16,11 +16,11 @@
 
 package io.phdata.pulse.alertengine.notification
 
+import com.typesafe.scalalogging.LazyLogging
 import io.phdata.pulse.alertengine.{ SlackAlertProfile, TriggeredAlert }
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.DefaultHttpClient
-import com.typesafe.scalalogging.LazyLogging
 
 class SlackNotificationService() extends LazyLogging {
   def notify(alerts: Iterable[TriggeredAlert], profile: SlackAlertProfile): Unit =

--- a/alert-engine/src/main/scala/io/phdata/pulse/alertengine/trigger/AbstractAlertTrigger.scala
+++ b/alert-engine/src/main/scala/io/phdata/pulse/alertengine/trigger/AbstractAlertTrigger.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pulse.alertengine.trigger
+
+import com.typesafe.scalalogging.Logger
+import io.phdata.pulse.alertengine.{ AlertRule, AlertsDb, TriggeredAlert }
+import org.slf4j.LoggerFactory
+
+/**
+ * An abstract class for alert triggers that handles the logic of when to query and when to trigger
+ * the alert. Children need only implement the query method to perform the query on the data source.
+ */
+abstract class AbstractAlertTrigger extends AlertTrigger {
+  protected lazy val _logger: Logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
+  def logger: Logger = _logger
+
+  /**
+   * Queries using the given alert rule to determine if an alert should be triggered.
+   * @param applicationName the application name
+   * @param alertRule the alert rule
+   * @return the matching documents if any
+   */
+  def query(applicationName: String, alertRule: AlertRule): Seq[Map[String, Any]]
+
+  override final def check(applicationName: String, alertRule: AlertRule): Option[TriggeredAlert] =
+    if (AlertsDb.shouldCheck(applicationName, alertRule)) {
+      try {
+        val results = query(applicationName, alertRule)
+        processResults(applicationName, alertRule, results)
+      } catch {
+        case e: Exception =>
+          e.printStackTrace()
+          logger.error(s"Error running query for $applicationName with alert $alertRule", e)
+          None
+      }
+    } else {
+      None
+    }
+
+  private def processResults(applicationName: String,
+                             alertRule: AlertRule,
+                             results: Seq[Map[String, Any]]): Option[TriggeredAlert] = {
+    val numFound  = results.size
+    val threshold = alertRule.resultThreshold.getOrElse(0)
+    if (threshold == -1 && results.isEmpty) {
+      logger.info(
+        s"Alert triggered for $applicationName on alert $alertRule at no results found condition")
+      AlertsDb.markTriggered(applicationName, alertRule)
+      Some(TriggeredAlert(alertRule, applicationName, results, 0))
+    } else if (results.lengthCompare(threshold) > 0) {
+      logger.info(s"Alert triggered for $applicationName on alert $alertRule")
+      AlertsDb.markTriggered(applicationName, alertRule)
+      Some(TriggeredAlert(alertRule, applicationName, results, numFound))
+    } else {
+      logger.info(s"No alert needed for $applicationName with alert $alertRule")
+      None
+    }
+  }
+}

--- a/alert-engine/src/main/scala/io/phdata/pulse/alertengine/trigger/AlertTrigger.scala
+++ b/alert-engine/src/main/scala/io/phdata/pulse/alertengine/trigger/AlertTrigger.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.phdata.pulse.alertengine.trigger
+
+import io.phdata.pulse.alertengine.{ AlertRule, TriggeredAlert }
+
+/**
+ * Checks if an alert rule should be triggered.
+ */
+trait AlertTrigger {
+
+  /**
+   * Checks if the alert rule should be triggered.
+   * If the 'resultThreshold' is 0 or greater, trigger if a result is found.
+   * If the 'resultThreshold' is less than 0, trigger if no documents are found.
+   * @param applicationName The application name
+   * @param alertRule       The alert rule to be checked
+   * @return an Option of [[io.phdata.pulse.alertengine.TriggeredAlert]]
+   */
+  def check(applicationName: String, alertRule: AlertRule): Option[TriggeredAlert]
+
+}

--- a/alert-engine/src/main/scala/io/phdata/pulse/alertengine/trigger/SolrAlertTrigger.scala
+++ b/alert-engine/src/main/scala/io/phdata/pulse/alertengine/trigger/SolrAlertTrigger.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pulse.alertengine.trigger
+
+import io.phdata.pulse.alertengine.AlertRule
+import io.phdata.pulse.common.SolrService
+
+/**
+ * Executes a solr query to determine if an alert should be triggered.
+ *
+ * @param solrService          Solr service used to run queries against solr collections
+ */
+class SolrAlertTrigger(solrService: SolrService) extends AbstractAlertTrigger {
+  override def query(applicationName: String, alertRule: AlertRule): Seq[Map[String, Any]] = {
+    val alias = s"${applicationName}_all"
+    solrService.query(alias, alertRule.query)
+  }
+}

--- a/alert-engine/src/main/scala/io/phdata/pulse/alertengine/trigger/SqlAlertTrigger.scala
+++ b/alert-engine/src/main/scala/io/phdata/pulse/alertengine/trigger/SqlAlertTrigger.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pulse.alertengine.trigger
+
+import java.sql.{ DriverManager, ResultSet, ResultSetMetaData }
+import java.util.Properties
+
+import io.phdata.pulse.alertengine.AlertRule
+
+case class ConnectionInfo(url: String, properties: Properties)
+
+object SqlAlertTrigger {
+  val MAX_ROWS = 10
+}
+
+/**
+ * Executes an SQL query to determine if an alert should be triggered.
+ * @param dbUrl the database url
+ * @param dbUser an optional database user
+ * @param dbPassword an optional database password
+ * @param dbOptions additional database options
+ */
+class SqlAlertTrigger(val dbUrl: String,
+                      val dbUser: Option[String] = None,
+                      val dbPassword: Option[String] = None,
+                      val dbOptions: Map[String, String] = Map.empty)
+    extends AbstractAlertTrigger {
+
+  if (dbUrl == null || dbUrl.trim.isEmpty) {
+    throw new IllegalArgumentException("dbUrl must be defined")
+  }
+
+  private def dbProperties: Properties = {
+    val props = new Properties()
+    dbUser.map(props.put("user", _))
+    dbPassword.map(props.put("password", _))
+    dbOptions.foreach { case (key, value) => props.put(key, value) }
+    props
+  }
+
+  override def query(applicationName: String, alertRule: AlertRule): Seq[Map[String, Any]] = {
+    val resultBuilder = List.newBuilder[Map[String, Any]]
+    val connection    = DriverManager.getConnection(dbUrl, dbProperties)
+    try {
+      val statement = connection.createStatement()
+      statement.closeOnCompletion()
+      statement.setMaxRows(SqlAlertTrigger.MAX_ROWS)
+      val resultSet = statement.executeQuery(alertRule.query)
+      try {
+        val md = resultSet.getMetaData
+        while (resultSet.next()) {
+          val doc = convertToMap(resultSet, md)
+          resultBuilder += doc
+        }
+      } finally {
+        resultSet.close()
+      }
+    } finally {
+      connection.close()
+    }
+    resultBuilder.result
+  }
+
+  /**
+   * Converts the current row to a Map.
+   * @param results the result set
+   * @param md the result set metadata
+   * @return the current row as a Map
+   */
+  private def convertToMap(results: ResultSet, md: ResultSetMetaData): Map[String, Any] =
+    (1 to md.getColumnCount)
+      .map(i => md.getColumnName(i).toLowerCase -> results.getObject(i))
+      .toMap
+
+}

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/AlertEngineCliParserTest.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/AlertEngineCliParserTest.scala
@@ -85,4 +85,49 @@ class AlertEngineCliParserTest extends FunSuite {
     assertResult(None)(cliParser.smtpPassword)
   }
 
+  test("Test database url") {
+    val args = Array(
+      "--conf",
+      "sample conf",
+      "--db-url=jdbc/something"
+    )
+
+    val cliParser = new AlertEngineCliParser(args)
+
+    assertResult("jdbc/something")(cliParser.dbUrl())
+  }
+
+  test("Test database user") {
+    val args = Array(
+      "--conf",
+      "sample conf",
+      "--db-user=me"
+    )
+
+    val cliParser = new AlertEngineCliParser(args)
+    assertResult("me")(cliParser.dbUser())
+  }
+
+  test("Test database password") {
+    val args = Array(
+      "--conf",
+      "sample conf",
+      "--db-password=hello"
+    )
+
+    val cliParser = new AlertEngineCliParser(args)
+    assertResult("hello")(cliParser.dbPassword())
+  }
+
+  test("Test database options") {
+    val args = Array(
+      "--conf",
+      "sample conf",
+      "--db-options=key1=value1;key2=value2"
+    )
+
+    val cliParser = new AlertEngineCliParser(args)
+    assertResult("key1=value1;key2=value2")(cliParser.dbOptions())
+  }
+
 }

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/AlertEngineImplTest.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/AlertEngineImplTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 phData Inc.
+ * Copyright 2019 phData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,108 +16,45 @@
 
 package io.phdata.pulse.alertengine
 
-import io.phdata.pulse.alertengine.notification.{
-  MailNotificationService,
-  NotificationServices,
-  SlackNotificationService
-}
-import io.phdata.pulse.common.SolrServiceImpl
-import io.phdata.pulse.solr.{ BaseSolrCloudTest, TestUtil }
-import org.mockito.Mockito
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{ BeforeAndAfterEach, FunSuite }
+import com.typesafe.scalalogging.Logger
+import io.phdata.pulse.alertengine.notification.{MailNotificationService, NotificationServices, SlackNotificationService}
+import io.phdata.pulse.alertengine.trigger.{SolrAlertTrigger, SqlAlertTrigger}
+import org.mockito.Mockito._
+import org.mockito.{Matchers, Mockito}
+import org.scalatest.{BeforeAndAfterEach, FunSuite}
+import org.scalatestplus.mockito.MockitoSugar
+import org.slf4j.LoggerFactory
 
-class AlertEngineImplTest
-    extends FunSuite
-    with BaseSolrCloudTest
-    with MockitoSugar
-    with BeforeAndAfterEach {
-  val CONF_NAME        = "testconf"
-  val APPLICATION_NAME = TestUtil.randomIdentifier()
+class AlertEngineImplTest extends FunSuite with MockitoSugar with BeforeAndAfterEach {
 
-  val mailNotificationService =
-    mock[MailNotificationService]
+  val mailNotificationService: MailNotificationService = mock[MailNotificationService]
+  val slackNotificationService: SlackNotificationService = mock[SlackNotificationService]
+  lazy val notificationServices: NotificationServices =
+    new NotificationServices(mailNotificationService, slackNotificationService)
 
-  val slackNotificationService =
-    mock[SlackNotificationService]
+  val solrAlertTrigger: SolrAlertTrigger = mock[SolrAlertTrigger]
+  val sqlAlertTrigger: SqlAlertTrigger = mock[SqlAlertTrigger]
+
+  val engine = new AlertEngineImpl(Some(solrAlertTrigger), Some(sqlAlertTrigger), notificationServices)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
     AlertsDb.reset()
-  }
+    reset(solrAlertTrigger, sqlAlertTrigger, mailNotificationService, slackNotificationService)
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    AlertsDb.reset()
-    val alias = APPLICATION_NAME + "_all"
-
-    solrClient.setDefaultCollection(alias)
-    solrService.createCollection(alias, 1, 1, CONF_NAME, null)
-
-    val documentError =
-      Map("category"  -> "ERROR",
-          "timestamp" -> "1970-01-01T00:00:00Z",
-          "level"     -> "ERROR2",
-          "message"   -> "message2",
-          "throwable" -> "Exception in thread main")
-
-    for (_ <- 1 to 12) {
-      addDocument(documentError)
-    }
-
-    solrClient.commit(true, true, true)
-    // unset the default collection so we are sure it is being set in the request
-    solrClient.setDefaultCollection("")
-  }
-
-  test("get active alert") {
-    val alertRule = TestObjectGenerator.alertRule(query = "category: ERROR",
-                                                  retryInterval = 1,
-                                                  resultThreshold = Some(1),
-                                                  alertProfiles = List("test@phdata.io"))
-
-    val engine =
-      new AlertEngineImpl(
-        solrService,
-        new NotificationServices(mailNotificationService, slackNotificationService))
-    val result = engine.triggeredAlert(APPLICATION_NAME, alertRule).get
-    assertResult(alertRule)(result.rule)
-    // @TODO why is this 2 instead of 1 sometimes?
-    assert(result.documents.lengthCompare(0) > 0)
-    assert(result.applicationName == APPLICATION_NAME)
-    assert(result.totalNumFound == 10)
-  }
-
-  test("trigger alert when threshold is set to '-1' and there are no results") {
-    val alertRule = TestObjectGenerator.alertRule(resultThreshold = Some(-1))
-    val engine =
-      new AlertEngineImpl(
-        solrService,
-        new NotificationServices(mailNotificationService, slackNotificationService))
-    val result = engine.triggeredAlert(APPLICATION_NAME, alertRule).get
-    assertResult(alertRule)(result.rule)
-    assert(result.documents.isEmpty)
-    assert(result.applicationName == APPLICATION_NAME)
-  }
-
-  test("don't match non alert") {
-    val alertRule = TestObjectGenerator.alertRule()
-    val engine =
-      new AlertEngineImpl(
-        solrService,
-        new NotificationServices(mailNotificationService, slackNotificationService))
-    assertResult(None)(engine.triggeredAlert(APPLICATION_NAME, alertRule))
+    when(solrAlertTrigger.query(Matchers.anyString, Matchers.any[AlertRule])).thenReturn(Seq.empty)
+    when(solrAlertTrigger.logger).thenReturn(Logger(LoggerFactory.getLogger(solrAlertTrigger.getClass)))
+    when(sqlAlertTrigger.query(Matchers.anyString, Matchers.any[AlertRule])).thenReturn(Seq.empty)
+    when(sqlAlertTrigger.logger).thenReturn(Logger(LoggerFactory.getLogger(sqlAlertTrigger.getClass)))
   }
 
   test("Mail profile is matched from AlertRule to Application") {
     val mailAlertProfile = TestObjectGenerator.mailAlertProfile()
 
     val alertRule = TestObjectGenerator.alertRule()
-    val engine =
-      new AlertEngineImpl(null, new NotificationServices(mailNotificationService, null))
 
-    val triggeredAlert  = TestObjectGenerator.triggeredAlert(documents = null)
-    val app             = Application("testApp", List(alertRule), Some(List(mailAlertProfile)), None)
+    val triggeredAlert = TestObjectGenerator.triggeredAlert(documents = Seq.empty)
+    val app = Application("testApp", List(alertRule), Some(List(mailAlertProfile)), None)
     val triggeredAlerts = List(triggeredAlert)
 
     engine.sendAlert(app, "mailprofile1", triggeredAlerts)
@@ -131,11 +68,9 @@ class AlertEngineImplTest
       TestObjectGenerator.slackAlertProfile(name = profileName, url = "https://slack.com")
 
     val alertRule = TestObjectGenerator.alertRule()
-    val engine =
-      new AlertEngineImpl(null, new NotificationServices(null, slackNotificationService))
 
-    val triggeredAlert  = TriggeredAlert(alertRule, "Spark", null, 1)
-    val app             = Application("testApp", List(alertRule), None, Some(List(slackAlertProfile)))
+    val triggeredAlert = TriggeredAlert(alertRule, "Spark", Seq.empty, 1)
+    val app = Application("testApp", List(alertRule), None, Some(List(slackAlertProfile)))
     val triggeredAlerts = List(triggeredAlert)
 
     engine.sendAlert(app, profileName, triggeredAlerts)
@@ -144,22 +79,17 @@ class AlertEngineImplTest
   }
 
   test("test groupTriggeredAlerts") {
-    val engine =
-      new AlertEngineImpl(
-        null,
-        new NotificationServices(mailNotificationService, slackNotificationService))
-
-    val alertRule  = TestObjectGenerator.alertRule(query = "spark1query")
+    val alertRule = TestObjectGenerator.alertRule(query = "spark1query")
     val alertRule1 = TestObjectGenerator.alertRule(query = "spark2query1")
     val alertRule2 = TestObjectGenerator.alertRule(query = "spark2query2")
-    val App1       = Application("spark1", List(alertRule), None, None)
-    val App2       = Application("spark2", List(alertRule1, alertRule2), None, None)
+    val app1 = Application("spark1", List(alertRule), None, None)
+    val app2 = Application("spark2", List(alertRule1, alertRule2), None, None)
 
     val triggeredAlerts =
       List(
-        (App1, Option(TestObjectGenerator.triggeredAlert(applicationName = "spark"))),
-        (App2, Option(TestObjectGenerator.triggeredAlert(applicationName = "spark1"))),
-        (App2, Option(TestObjectGenerator.triggeredAlert(applicationName = "spark2")))
+        (app1, Option(TestObjectGenerator.triggeredAlert(applicationName = "spark"))),
+        (app2, Option(TestObjectGenerator.triggeredAlert(applicationName = "spark1"))),
+        (app2, Option(TestObjectGenerator.triggeredAlert(applicationName = "spark2")))
       )
 
     val groupedTriggerdAlerts =
@@ -175,12 +105,9 @@ class AlertEngineImplTest
 
     val alertRule = TestObjectGenerator.alertRule()
 
-    val activeApp        = Application("activeApp", List(alertRule), None, None)
-    val silencedApp      = Application("silencedApp", List(alertRule), None, None)
+    val activeApp = Application("activeApp", List(alertRule), None, None)
+    val silencedApp = Application("silencedApp", List(alertRule), None, None)
     val silencedAppNames = List("silencedApp")
-
-    val engine =
-      new AlertEngineImpl(null, null)
 
     val results = engine.filterSilencedApplications(List(activeApp, silencedApp), silencedAppNames)
     println(results)
@@ -188,45 +115,136 @@ class AlertEngineImplTest
     assert(results.contains(activeApp))
   }
 
-  test("mark alert triggered on results found > 0") {
+  test("test allTriggeredAlerts") {
+    val alertRule = TestObjectGenerator.alertRule(query = "spark1query", alertType = Some(AlertTypes.SOLR))
+    val alertRule1 = TestObjectGenerator.alertRule(query = "spark2query1", alertType=Some(AlertTypes.SOLR))
+    val alertRule2 = TestObjectGenerator.alertRule(query = "spark2query2", alertType = Some(AlertTypes.SOLR))
+    val app1 = Application("spark1", List(alertRule), None, None)
+    val app2 = Application("spark2", List(alertRule1, alertRule2), None, None)
+    val docs = Seq[Map[String, Any]](Map.empty, Map.empty)
+    when(solrAlertTrigger.query(Matchers.anyString(), Matchers.any[AlertRule])).thenReturn(docs)
+
+    val alert1 =
+      Option(TestObjectGenerator.triggeredAlert(applicationName = "spark1", rule = alertRule, totalNumFound = 2, documents = docs))
+    val alert2 =
+      Option(TestObjectGenerator.triggeredAlert(applicationName = "spark2", rule = alertRule1, totalNumFound = 2, documents = docs))
+    val alert3 =
+      Option(TestObjectGenerator.triggeredAlert(applicationName = "spark2", rule = alertRule2, totalNumFound = 2, documents = docs))
+
+    val expected =
+      List(
+        (app1, alert1),
+        (app2, alert2),
+        (app2, alert3)
+      )
+
+    val results = engine.allTriggeredAlerts(List(app1, app2))
+    assertResult(expected)(results)
+  }
+
+  test("test run") {
+    val alertRule1 =
+      TestObjectGenerator.alertRule(query = "spark1query", alertProfiles = List("email"))
+    val alertRule2 =
+      TestObjectGenerator.alertRule(query = "spark2query1", alertProfiles = List("slack"))
+    val alertRule3 =
+      TestObjectGenerator.alertRule(query = "spark2query2", alertProfiles = List("slack"))
+    val alertRule4 =
+      TestObjectGenerator.alertRule(query = "spark3query1", alertProfiles = List("unused"))
+
+    val docs = Seq[Map[String, Any]](Map.empty, Map.empty)
+    when(solrAlertTrigger.query(Matchers.anyString(), Matchers.any[AlertRule])).thenReturn(docs)
+
+    val alert1 =
+      Option(TestObjectGenerator.triggeredAlert(applicationName = "spark1", rule = alertRule1, totalNumFound = 2, documents = docs))
+    val alert2 =
+      Option(TestObjectGenerator.triggeredAlert(applicationName = "spark2", rule = alertRule2, totalNumFound = 2, documents = docs))
+    val alert3 =
+      Option(TestObjectGenerator.triggeredAlert(applicationName = "spark2", rule = alertRule3, totalNumFound = 2, documents = docs))
+    val alert4 =
+      Option(TestObjectGenerator.triggeredAlert(applicationName = "spark3", rule = alertRule4, totalNumFound = 2, documents = docs))
+
+    val mailAlertProfile = TestObjectGenerator.mailAlertProfile(name = "email")
+    val slackAlertProfile = TestObjectGenerator.slackAlertProfile(name = "slack")
+    val app1 = Application("spark1", List(alertRule1), Some(List(mailAlertProfile)), None)
+    val app2 =
+      Application("spark2", List(alertRule2, alertRule3), None, Some(List(slackAlertProfile)))
+    val app3 = Application("spark3", List(alertRule4), None, None)
+
+    engine.run(List(app1, app3, app2), List(app3.name))
+
+    Mockito.verify(mailNotificationService).notify(List(alert1.get), mailAlertProfile)
+    Mockito.verify(slackNotificationService).notify(List(alert2.get, alert3.get), slackAlertProfile)
+  }
+
+  test("SolrAlertTrigger called") {
     val alertRule = TestObjectGenerator.alertRule(query = "category: ERROR",
-                                                  retryInterval = 1,
-                                                  alertProfiles = List("testing@tester.com"))
-    val engine =
-      new AlertEngineImpl(
-        solrService,
-        new NotificationServices(mailNotificationService, slackNotificationService))
-    val result = engine.triggeredAlert(APPLICATION_NAME, alertRule).get
-    assertResult(false)(AlertsDb.shouldCheck(APPLICATION_NAME, alertRule))
+      retryInterval = 1,
+      resultThreshold = Some(1),
+      alertProfiles = List("test@phdata.io"),
+      Some(AlertTypes.SOLR))
+    val applicationName = "some-name"
+    val docs = Seq[Map[String, Any]](Map.empty, Map.empty)
+    val expected =
+      Some(TestObjectGenerator.triggeredAlert(applicationName = applicationName, rule = alertRule, totalNumFound = docs.length, documents =docs ))
+    when(solrAlertTrigger.query(applicationName, alertRule)).thenReturn(docs)
+
+    val result = engine.triggeredAlert(applicationName, alertRule)
+    assertResult(expected)(result)
+    verify(solrAlertTrigger).query(applicationName, alertRule)
+    verifyZeroInteractions(sqlAlertTrigger)
   }
 
-  test("mark alert triggered when results are found") {
-    val alertRule = TestObjectGenerator.alertRule(query = "category: ERROR", retryInterval = 1)
-    val engine =
-      new AlertEngineImpl(
-        solrService,
-        new NotificationServices(mailNotificationService, slackNotificationService))
-    assert(engine.triggeredAlert(APPLICATION_NAME, alertRule).isDefined)
-    assertResult(false)(AlertsDb.shouldCheck(APPLICATION_NAME, alertRule))
+  test("SolrAlertTrigger called when no alert type is defined") {
+    val alertRule = TestObjectGenerator.alertRule(query = "category: ERROR",
+      retryInterval = 1,
+      resultThreshold = Some(1),
+      alertProfiles = List("test@phdata.io"),
+      None)
+    val applicationName = "some-name"
+    val docs = Seq[Map[String, Any]](Map.empty, Map.empty)
+    val expected =
+      Some(TestObjectGenerator.triggeredAlert(applicationName = applicationName, rule = alertRule, totalNumFound = docs.length, documents = docs))
+    when(solrAlertTrigger.query(applicationName, alertRule)).thenReturn(docs)
+
+    val result = engine.triggeredAlert(applicationName, alertRule)
+    assertResult(expected)(result)
+    verify(solrAlertTrigger).query(applicationName, alertRule)
+    verifyZeroInteractions(sqlAlertTrigger)
   }
 
-  test("mark alert triggered when no results are found") {
-    val alertRule = TestObjectGenerator.alertRule(resultThreshold = Some(-1))
-    val engine =
-      new AlertEngineImpl(
-        solrService,
-        new NotificationServices(mailNotificationService, slackNotificationService))
-    assert(engine.triggeredAlert(APPLICATION_NAME, alertRule).isDefined)
-    assertResult(false)(AlertsDb.shouldCheck(APPLICATION_NAME, alertRule))
+  test("SqlAlertTrigger called") {
+    val alertRule = TestObjectGenerator.alertRule(query = "category: ERROR",
+      retryInterval = 1,
+      resultThreshold = Some(1),
+      alertProfiles = List("test@phdata.io"),
+      Some(AlertTypes.SQL))
+    val applicationName = "some-name"
+    val docs = Seq[Map[String, Any]](Map.empty, Map.empty)
+    val expected =
+      Some(TestObjectGenerator.triggeredAlert(applicationName = applicationName, rule = alertRule, totalNumFound = docs.length, documents = docs))
+    when(sqlAlertTrigger.query(applicationName, alertRule)).thenReturn(docs)
+
+    val result = engine.triggeredAlert(applicationName, alertRule)
+    assertResult(expected)(result)
+    verify(sqlAlertTrigger).query(applicationName, alertRule)
+    verifyZeroInteractions(solrAlertTrigger)
   }
 
-  test("don't mark alert triggered when no results are found") {
-    val alertRule = TestObjectGenerator.alertRule(resultThreshold = Some(1))
-    val engine =
-      new AlertEngineImpl(
-        solrService,
-        new NotificationServices(mailNotificationService, slackNotificationService))
-    assertResult(None)(engine.triggeredAlert(APPLICATION_NAME, alertRule))
-    assertResult(true)(AlertsDb.shouldCheck(APPLICATION_NAME, alertRule))
+  test("No matching alert trigger") {
+    val alertRule = TestObjectGenerator.alertRule(query = "category: ERROR",
+      retryInterval = 1,
+      resultThreshold = Some(1),
+      alertProfiles = List("test@phdata.io"),
+      Some("blah"))
+
+    val result = engine.triggeredAlert("hi", alertRule)
+    verifyZeroInteractions(solrAlertTrigger)
+    verifyZeroInteractions(sqlAlertTrigger)
   }
+
+  test("No alert triggers provided") {
+    assertThrows[IllegalStateException](new AlertEngineImpl(None, None, notificationServices))
+  }
+
 }

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/AlertEngineMainTest.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/AlertEngineMainTest.scala
@@ -40,4 +40,109 @@ class AlertEngineMainTest extends FunSuite {
       .readSilencedApplications("/foo/bar")
   }
 
+  test("findAlertTypes finds the expected types") {
+    val alertRule1 = TestObjectGenerator.alertRule(query = "spark2query1", alertType = Some(AlertTypes.SQL))
+    val alertRule2 = TestObjectGenerator.alertRule(query = "spark2query2", alertType=Some(AlertTypes.SQL))
+    val alertRule3 = TestObjectGenerator.alertRule(query = "spark2query3", alertType=Some(AlertTypes.SOLR))
+    val apps = List(
+      Application("spark1", List(alertRule1), None, None),
+      Application("spark2", List(alertRule2, alertRule3), None, None)
+    )
+
+    val results = AlertEngineMain.findAlertTypes(apps)
+    assertResult(Set(AlertTypes.SOLR, AlertTypes.SQL))(results)
+  }
+
+  test("findAlertTypes throws exception on unknown alert type") {
+    val alertRule1 = TestObjectGenerator.alertRule(query = "spark2query1", alertType = Some(AlertTypes.SQL))
+    val alertRule2 = TestObjectGenerator.alertRule(query = "spark2query2", alertType=Some("blah"))
+    val alertRule3 = TestObjectGenerator.alertRule(query = "spark2query3", alertType=Some(AlertTypes.SOLR))
+    val apps = List(
+     Application("spark1", List(alertRule1), None, None),
+     Application("spark2", List(alertRule2, alertRule3), None, None)
+    )
+
+    assertThrows[IllegalStateException](AlertEngineMain.findAlertTypes(apps))
+  }
+
+  test("findAlertTypes returns solr alert type when alert type is not defined") {
+    val alertRule1 = TestObjectGenerator.alertRule(query = "spark2query1", alertType = None)
+    val apps = List(
+      Application("spark1", List(alertRule1), None, None)
+    )
+
+    assertResult(Set(AlertTypes.SOLR))(AlertEngineMain.findAlertTypes(apps))
+  }
+
+  test("createSolrAlertTrigger fails without zkHost") {
+    val args = Array(
+      "--conf",
+      "sample conf"
+    )
+
+    val parser = new AlertEngineCliParser(args)
+    assertThrows[IllegalStateException](AlertEngineMain.createSolrAlertTrigger(parser))
+  }
+
+  test("createSqlAlertTrigger fails without database URL") {
+    val args = Array(
+      "--conf",
+      "sample conf"
+    )
+
+    val parser = new AlertEngineCliParser(args)
+    assertThrows[IllegalStateException](AlertEngineMain.createSqlAlertTrigger(parser))
+  }
+
+  test("createSqlAlertTrigger fails on invalid db options") {
+    val args = Array(
+      "--conf",
+      "sample conf",
+      "--db-url=hello",
+      "--db-options=blarg=1=2"
+    )
+
+    val parser = new AlertEngineCliParser(args)
+    assertThrows[IllegalArgumentException](AlertEngineMain.createSqlAlertTrigger(parser))
+  }
+
+  test("createSqlAlertTrigger user is None") {
+    val args = Array(
+      "--conf",
+      "sample conf",
+      "--db-url=hello",
+      "--db-user="
+    )
+
+    val parser = new AlertEngineCliParser(args)
+    val trigger = AlertEngineMain.createSqlAlertTrigger(parser)
+    assertResult(None)(trigger.dbUser)
+  }
+
+  test("createSqlAlertTrigger password is None") {
+    val args = Array(
+      "--conf",
+      "sample conf",
+      "--db-url=hello",
+      "--db-password="
+    )
+
+    val parser = new AlertEngineCliParser(args)
+    val trigger = AlertEngineMain.createSqlAlertTrigger(parser)
+    assertResult(None)(trigger.dbPassword)
+  }
+
+  test("createSqlAlertTrigger db options are empty") {
+    val args = Array(
+      "--conf",
+      "sample conf",
+      "--db-url=hello",
+      "--db-options="
+    )
+
+    val parser = new AlertEngineCliParser(args)
+    val trigger = AlertEngineMain.createSqlAlertTrigger(parser)
+    assertResult(Map.empty)(trigger.dbOptions)
+  }
+
 }

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestObjectGenerator.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/TestObjectGenerator.scala
@@ -17,7 +17,6 @@
 package io.phdata.pulse.alertengine
 
 import io.phdata.pulse.common.domain.LogEvent
-import org.apache.solr.common.SolrDocument
 
 /**
  * TestObjectGenerator helps avoid redundant test object creation by providing methods
@@ -115,8 +114,9 @@ object TestObjectGenerator {
   def alertRule(query: String = "id : testId",
                 retryInterval: Int = 10,
                 resultThreshold: Option[Int] = None,
-                alertProfiles: List[String] = List("mailprofile1")): AlertRule =
-    AlertRule(query, retryInterval, resultThreshold, alertProfiles)
+                alertProfiles: List[String] = List("mailprofile1"),
+                alertType: Option[String] = Some(AlertTypes.SOLR)): AlertRule =
+    AlertRule(query, retryInterval, resultThreshold, alertProfiles, alertType)
 
   /**
    * Method for creating test triggered alerts
@@ -129,7 +129,7 @@ object TestObjectGenerator {
    */
   def triggeredAlert(rule: AlertRule = alertRule(),
                      applicationName: String = "Spark",
-                     documents: Seq[Map[String, String]] = Seq(solrDocument()),
+                     documents: Seq[Map[String, Any]] = Seq(solrDocument()),
                      totalNumFound: Long = 20): TriggeredAlert =
     TriggeredAlert(rule, applicationName, documents, totalNumFound)
 }

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/trigger/AbstractAlertTriggerTest.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/trigger/AbstractAlertTriggerTest.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pulse.alertengine.trigger
+
+import io.phdata.pulse.alertengine.{AlertsDb, TestObjectGenerator}
+import io.phdata.pulse.solr.TestUtil
+import org.mockito.Mockito
+import org.mockito.Mockito._
+import org.scalatest.{BeforeAndAfterEach, FunSuite}
+import org.scalatestplus.mockito.MockitoSugar
+
+class AbstractAlertTriggerTest extends FunSuite with MockitoSugar with BeforeAndAfterEach {
+  val applicationName = TestUtil.randomIdentifier()
+
+  val trigger = Mockito.mock(classOf[AbstractAlertTrigger], Mockito.CALLS_REAL_METHODS)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    AlertsDb.reset()
+    Mockito.reset(trigger)
+  }
+
+  test("get active alert") {
+    val alertRule = TestObjectGenerator.alertRule(query = "category: ERROR",
+                                                  retryInterval = 1,
+                                                  resultThreshold = Some(1),
+                                                  alertProfiles = List("test@phdata.io"))
+    when(trigger.query(applicationName, alertRule))
+      .thenReturn(Seq[Map[String, Any]](Map.empty, Map.empty))
+
+    val result = trigger.check(applicationName, alertRule).get
+    assertResult(alertRule)(result.rule)
+    assertResult(2)(result.documents.length)
+    assertResult(applicationName)(result.applicationName)
+    assertResult(2)(result.totalNumFound)
+  }
+
+  test("trigger alert when threshold is set to '-1' and there are no results") {
+    val alertRule = TestObjectGenerator.alertRule(resultThreshold = Some(-1))
+    when(trigger.query(applicationName, alertRule)).thenReturn(Seq.empty)
+
+    val result = trigger.check(applicationName, alertRule).get
+    assertResult(alertRule)(result.rule)
+    assert(result.documents.isEmpty)
+    assert(result.applicationName == applicationName)
+  }
+
+  test("don't match non alert") {
+    val alertRule = TestObjectGenerator.alertRule()
+    when(trigger.query(applicationName, alertRule)).thenReturn(Seq.empty)
+
+    assertResult(None)(trigger.check(applicationName, alertRule))
+  }
+
+  test("mark alert triggered on results found > 0") {
+    val alertRule = TestObjectGenerator.alertRule(query = "category: ERROR",
+                                                  retryInterval = 1,
+                                                  alertProfiles = List("testing@tester.com"))
+    when(trigger.query(applicationName, alertRule))
+      .thenReturn(Seq[Map[String, Any]](Map.empty, Map.empty))
+
+    assert(trigger.check(applicationName, alertRule).isDefined)
+    assertResult(false)(AlertsDb.shouldCheck(applicationName, alertRule))
+  }
+
+  test("mark alert triggered when results are found") {
+    val alertRule = TestObjectGenerator.alertRule(query = "category: ERROR", retryInterval = 1)
+    when(trigger.query(applicationName, alertRule))
+      .thenReturn(Seq[Map[String, Any]](Map.empty, Map.empty))
+
+    assert(trigger.check(applicationName, alertRule).isDefined)
+    assertResult(false)(AlertsDb.shouldCheck(applicationName, alertRule))
+  }
+
+  test("mark alert triggered when no results are found") {
+    val alertRule = TestObjectGenerator.alertRule(resultThreshold = Some(-1))
+    when(trigger.query(applicationName, alertRule)).thenReturn(Seq.empty)
+
+    assert(trigger.check(applicationName, alertRule).isDefined)
+    assertResult(false)(AlertsDb.shouldCheck(applicationName, alertRule))
+  }
+
+  test("don't mark alert triggered when no results are found") {
+    val alertRule = TestObjectGenerator.alertRule(resultThreshold = Some(1))
+    when(trigger.query(applicationName, alertRule)).thenReturn(Seq.empty)
+
+    assertResult(None)(trigger.check(applicationName, alertRule))
+    assertResult(true)(AlertsDb.shouldCheck(applicationName, alertRule))
+  }
+
+  test("don't check if already triggered") {
+    val alertRule = TestObjectGenerator.alertRule(resultThreshold = Some(1))
+    AlertsDb.markTriggered(applicationName, alertRule)
+    assertResult(None)(trigger.check(applicationName, alertRule))
+    assertResult(false)(AlertsDb.shouldCheck(applicationName, alertRule))
+  }
+
+  test("query exception") {
+    val alertRule = TestObjectGenerator.alertRule()
+    when(trigger.query(applicationName, alertRule)).thenThrow(new RuntimeException("fake bad thing"))
+
+    assertResult(None)(trigger.check(applicationName, alertRule))
+  }
+
+}

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/trigger/SolrAlertTriggerTest.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/trigger/SolrAlertTriggerTest.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pulse.alertengine.trigger
+
+import io.phdata.pulse.alertengine.{ AlertsDb, TestObjectGenerator }
+import io.phdata.pulse.solr.{ BaseSolrCloudTest, TestUtil }
+import org.scalatest.BeforeAndAfterEach
+
+class SolrAlertTriggerTest extends BaseSolrCloudTest with BeforeAndAfterEach {
+  val CONF_NAME               = "testconf"
+  private val applicationName = TestUtil.randomIdentifier()
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    AlertsDb.reset()
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    AlertsDb.reset()
+    val alias = applicationName + "_all"
+
+    solrClient.setDefaultCollection(alias)
+    solrService.createCollection(alias, 1, 1, CONF_NAME, null)
+
+    Seq[Map[String, String]](
+      Map("id" -> "1", "level" -> "ERROR", "message" -> "sad"),
+      Map("id" -> "2", "level" -> "INFO", "message"  -> "happy"),
+      Map("id" -> "3", "level" -> "ERROR", "message" -> "very sad")
+    ).foreach(addDocument)
+
+    solrClient.commit(true, true, true)
+    // unset the default collection so we are sure it is being set in the request
+    solrClient.setDefaultCollection("")
+  }
+
+  private def stripVersion(result: Seq[Map[String, Any]]): Seq[Map[String, Any]] = {
+    result.collect {
+      case doc: Map[String, Any] =>
+      assert(doc.contains("_version_"))
+      doc - "_version_"
+    }
+  }
+
+  test("query returns matching documents") {
+    val alertRule =
+      TestObjectGenerator.alertRule(
+        query = "level:ERROR",
+        retryInterval = 1,
+        resultThreshold = Some(1),
+        alertProfiles = List("test@phdata.io")
+      )
+    val expectedDocuments = Seq(
+      Map("id" -> "1", "level" -> "ERROR", "message" -> "sad"),
+      Map("id" -> "3", "level" -> "ERROR", "message" -> "very sad")
+    )
+
+    val trigger = new SolrAlertTrigger(solrService)
+    val result  = trigger.query(applicationName, alertRule)
+    val modifiedResult = stripVersion(result)
+    assertResult(expectedDocuments)(modifiedResult)
+  }
+
+  test("query returns no documents") {
+    val alertRule = TestObjectGenerator.alertRule(query = "level:WARN")
+
+    val trigger = new SolrAlertTrigger(solrService)
+    assertResult(Seq.empty)(trigger.query(applicationName, alertRule))
+  }
+
+  test("invalid query") {
+    val alertRule = TestObjectGenerator.alertRule(query = ":")
+
+    val trigger = new SolrAlertTrigger(solrService)
+    assertThrows[Exception](trigger.query(applicationName, alertRule))
+  }
+
+}

--- a/alert-engine/src/test/scala/io/phdata/pulse/alertengine/trigger/SqlAlertTriggerTest.scala
+++ b/alert-engine/src/test/scala/io/phdata/pulse/alertengine/trigger/SqlAlertTriggerTest.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 phData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.phdata.pulse.alertengine.trigger
+
+import java.sql.{ DriverManager, Statement }
+
+import io.phdata.pulse.alertengine.{ AlertsDb, TestObjectGenerator }
+import io.phdata.pulse.solr.TestUtil
+import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, FunSuite }
+
+class SqlAlertTriggerTest extends FunSuite with BeforeAndAfterEach with BeforeAndAfterAll {
+  private val applicationName: String = "sql_test_" + TestUtil.randomIdentifier()
+  private val dbUrl                   = s"jdbc:h2:mem:$applicationName;DB_CLOSE_DELAY=-1"
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    AlertsDb.reset()
+    prepareDatabase()
+  }
+
+  override def afterAll(): Unit =
+    withStatement(statement => statement.execute("DROP ALL OBJECTS DELETE FILES;"))
+
+  private def withStatement(function: Statement => Unit): Unit = {
+    val connection = DriverManager.getConnection(dbUrl)
+    try {
+      val statement = connection.createStatement()
+      try {
+        function.apply(statement)
+      } finally {
+        statement.close()
+      }
+    } finally {
+      connection.close()
+    }
+  }
+
+  private def prepareDatabase(): Unit =
+    withStatement { statement =>
+      statement.execute("DROP ALL OBJECTS DELETE FILES;")
+      statement.execute(s"""CREATE TABLE $applicationName (
+           |id int not null,
+           |error boolean not null,
+           |message varchar(255) not null,
+           |);""".stripMargin)
+    }
+
+  test("query returns matching documents") {
+    withStatement { statement =>
+      statement.execute(s"""INSERT INTO $applicationName (id, error, message) VALUES
+           |(1, true, 'sad'),
+           |(3, true, 'very sad'),
+           |(2, false, 'happy');""".stripMargin)
+    }
+    val alertRule =
+      TestObjectGenerator.alertRule(
+        query = s"""select * from $applicationName
+           |where error = true
+           |order by id""".stripMargin,
+        retryInterval = 1,
+        resultThreshold = Some(1),
+        alertProfiles = List("test@phdata.io")
+      )
+    val expectedDocuments = Seq(
+      Map("id" -> 1, "error" -> true, "message" -> "sad"),
+      Map("id" -> 3, "error" -> true, "message" -> "very sad")
+    )
+
+    val trigger = new SqlAlertTrigger(dbUrl)
+    val result  = trigger.query(applicationName, alertRule)
+    assertResult(expectedDocuments)(result)
+  }
+
+  test("query returns no documents") {
+    val alertRule = TestObjectGenerator.alertRule(query = s"select * from $applicationName")
+
+    val trigger = new SqlAlertTrigger(dbUrl)
+    assertResult(Seq.empty)(trigger.query(applicationName, alertRule))
+  }
+
+  test("invalid query") {
+    val alertRule = TestObjectGenerator.alertRule()
+
+    val trigger = new SqlAlertTrigger(dbUrl)
+    assertThrows[Exception](trigger.query(applicationName, alertRule))
+  }
+
+  test("connection with options") {
+    val alertRule = TestObjectGenerator.alertRule(query = s"select * from $applicationName")
+
+    val trigger = new SqlAlertTrigger(dbUrl, dbOptions = Map("hello" -> "stuff"))
+    trigger.query(applicationName, alertRule)
+  }
+
+  test("dbUrl null") {
+    assertThrows[IllegalArgumentException](new SqlAlertTrigger(null))
+  }
+
+  test("dbUrl empty") {
+    assertThrows[IllegalArgumentException](new SqlAlertTrigger(""))
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import sbt.Keys._
 import sbt._
-import sys.process._
 
 name := "pulse"
 organization in ThisBuild := "io.phdata"
@@ -127,6 +126,8 @@ lazy val dependencies =
     val http = Seq(akkaHttp, akkaHttpSprayJson, akkaCors, akkaTestKit, akkaHttpTest)
 
     val mocking = Seq(mockito, powermock, powerMockApi, powerMockJunit)
+
+    val h2 = "com.h2database" % "h2" % "1.4.199" % Test
   }
 
 lazy val settings = commonSettings ++ scalafmtSettings ++ assemblySettings
@@ -195,7 +196,8 @@ lazy val `alert-engine` = project
     libraryDependencies ++= dependencies.common ++ dependencies.solr ++ Seq(dependencies.javaMail) ++ Seq(
       dependencies.scalaYaml,
       dependencies.sprayJson,
-      dependencies.scallop) ++ dependencies.mocking
+      dependencies.scallop,
+      dependencies.h2) ++ dependencies.mocking
   )
   .dependsOn(common)
   .dependsOn(solrModule)

--- a/docs/alerting-engine.md
+++ b/docs/alerting-engine.md
@@ -25,6 +25,7 @@ applications:
     resultThreshold: 0 # If the threshold is set to `-1` it will throw an alert if no results are returned
     alertProfiles:
     - mailProfile1
+    alertType: solr # optional, defaults to "solr" when not specified
   emailProfiles:
   - name: mailProfile1
     addresses:
@@ -41,12 +42,13 @@ The top-level object of the configuration file is a list of applications.
 An application consists of two things, alerts and profiles. Alerts tell the AlertEngine what to alert on. Profiles are used to set up connections to services like email or chat clients. As many profiles can be defined as needed, so you can send alerts through both email and Slack, or any number of services.
 An alert rule consists of
 
-- query: Solr Query that acts as a predicate, for example this query Solr: 
+- query: A query that acts as a predicate, for example this query Solr: 
 `timestamp:[NOW-10MINUTES TO NOW] AND level: ERROR` will trigger an alert if any message with level
- 'ERROR' is found within the last 10 minutes
+ 'ERROR' is found within the last 10 minutes. An SQL query must be provided if the `alertType` is `sql`.
 - retryInterval: the query will be run on the retry interval. The retry interval is set in minutes
 - threshold: if the query returns more than threshold results, an alert will be triggered. The default is 0. If the threshold is set to `-1`, the non-existence of documents with this query will trigger an alert. This is useful for tracking application uptime.
 - alertProfiles: One or many alertProfiles can be defined. For each alertProfile defined in an alert, an alertProfile needs to be defined for the application
+- alertType: An optional setting which defaults to `solr` when not specified. The valid values are `solr` and `sql`.
 
 ## Silenced applications
 A silenced application file can be provided `--silenced-application-file silenced-applications.txt`
@@ -65,5 +67,9 @@ java -Dlogback.configurationFile=logback.xml \
     --smtp-port 25 \
     --conf example-configs/alert-engine/alert-engine.yml \
     --silenced-application-file silenced-applications.txt
+    --db-url jdbc:mysql://host:port/db
+    --db-user some_user
+    --db-password some_password
+    --db-options "key1=value1;key2=value2"
 ```
  


### PR DESCRIPTION
Currently Pulse only supports a single alert engine based on Solr. Pulse needs to support configurable alert engines in general so that a JDBC alert engine can be added.