### PR TITLE
Use anonymous function in Kerberos 'run' call

### DIFF
--- a/log-collector/src/main/scala/io/phdata/pulse/logcollector/LogCollector.scala
+++ b/log-collector/src/main/scala/io/phdata/pulse/logcollector/LogCollector.scala
@@ -51,7 +51,7 @@ object LogCollector extends LazyLogging {
       }
       case _ => {
         KerberosUtil.scheduledLogin(0, 9, TimeUnit.HOURS)
-        KerberosUtil.run(start(args))
+        KerberosUtil.run(() => start(args))
       }
     }
 


### PR DESCRIPTION
When using the by-name parameter the 'start' function wasn't actually
being run inside of the priveleged block, but oddly the anonymous function
works