### PR TITLE
Use kerberos priveleged block on each Kudu call

### DIFF
--- a/log-collector/src/main/scala/io/phdata/pulse/logcollector/KerberosContext.scala
+++ b/log-collector/src/main/scala/io/phdata/pulse/logcollector/KerberosContext.scala
@@ -25,11 +25,13 @@ import javax.security.auth.login.LoginContext
 import monix.execution.Cancelable
 import monix.execution.Scheduler.{ global => scheduler }
 
-object KerberosUtil extends LazyLogging {
+object KerberosContext extends LazyLogging {
 
-  private val lc = new LoginContext("Client")
+  lazy private val loginContext = new LoginContext("Client")
+  private var useKerberos       = false
 
-  def scheduledLogin(initialDelay: Long, delay: Long, timeUnit: TimeUnit): Cancelable = {
+  def scheduleKerberosLogin(initialDelay: Long, delay: Long, timeUnit: TimeUnit): Cancelable = {
+    useKerberos = true
     val runnableLogin = new Runnable {
       def run(): Unit =
         login()
@@ -37,24 +39,33 @@ object KerberosUtil extends LazyLogging {
     scheduler.scheduleWithFixedDelay(initialDelay, delay, timeUnit, runnableLogin)
   }
 
-  def run[F](function: () => Any): Any =
-    Subject.doAs(lc.getSubject, new PrivilegedAction[Any]() {
-      override def run: Any = {
-        logger.info("Run block started")
-        function()
-        logger.info("Run block complete")
-      }
-    })
+  def runPrivileged[W](work: => W): W =
+    if (useKerberos) {
+      Subject.doAs(
+        loginContext.getSubject,
+        new PrivilegedAction[W]() {
+          override def run: W = {
+            logger.debug("Privileged block started")
+            val result = work
+            logger.debug("Privileged block complete")
+            result
+          }
+        }
+      )
+    } else {
+      logger.debug("Kerberos disabled. To enable kerberos call the `scheduleKerberosLogin` method.")
+      work
+    }
 
-  def login(): Unit = {
-    lc.login()
-    logger.info(s"Logging in with kerberos configuration:\n$getSubject")
+  private def login(): Unit = {
+    loginContext.login()
+    logger.info(s"Logged in with kerberos configuration:\n$getSubject")
   }
 
-  def getSubject: String =
-    if (lc.getSubject == null) {
+  private def getSubject: String =
+    if (loginContext.getSubject == null) {
       throw new Exception("Subject for LoginContext is null")
     } else {
-      lc.getSubject.toString
+      loginContext.getSubject.toString
     }
 }

--- a/log-collector/src/main/scala/io/phdata/pulse/logcollector/LogCollector.scala
+++ b/log-collector/src/main/scala/io/phdata/pulse/logcollector/LogCollector.scala
@@ -47,12 +47,13 @@ object LogCollector extends LazyLogging {
       case null => {
         logger.info(
           "java.security.auth.login.config is not set, continuing without kerberos authentication")
-        start(args)
       }
       case _ => {
-        KerberosUtil.scheduledLogin(0, 9, TimeUnit.HOURS)
-        KerberosUtil.run(() => start(args))
+        KerberosContext.scheduleKerberosLogin(0, 9, TimeUnit.HOURS)
       }
+
+      start(args)
+
     }
 
   private def start(args: Array[String]): Unit = {


### PR DESCRIPTION
When the Akka Server starts it returns a Future and the privileged block
would return immediately, none of the Kudu calls would run in the
privileged block. Instead, this wraps all kudu calls in the priveleged
block.