### PR TITLE
Update the log appender example to sleep for 10 ms

### DIFF
--- a/bin/log4j-appender-example
+++ b/bin/log4j-appender-example
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -eu
-java -Dlog4j.debug=true -Dlog4j.configuration=file:log-example/src/main/resources/log4j.properties -cp "target/lib/appenders/*:log-example/target/scala-2.11/*"  io.phdata.pulse.example.StandaloneAppExample 100000000 0
+java -Dlog4j.debug=true -Dlog4j.configuration=file:log-example/src/main/resources/log4j.properties -cp "target/lib/appenders/*:log-example/target/scala-2.11/*"  io.phdata.pulse.example.StandaloneAppExample 100000000 10


### PR DESCRIPTION
Changed the sleep time from 0 to 10 ms. If we don't adjust this the log appender creates messages too fast for the log collector and solr to keep up and the log collector will die.