### PR TITLE
Fixes streaming buffer

### DIFF
--- a/log-appender/src/main/java/io/phdata/pulse/log/HttpAppender.java
+++ b/log-appender/src/main/java/io/phdata/pulse/log/HttpAppender.java
@@ -39,348 +39,161 @@ import scala.concurrent.duration.FiniteDuration;
  */
 public class HttpAppender extends AppenderSkeleton {
 
-  private static final String HOSTNAME = "hostname";
-  private static final String SPARK_CONTAINER_ID = "container_id";
-  private static final String SPARK_APPLICATION_ID = "application_id";
+    private static final String HOSTNAME = "hostname";
+    private static final String SPARK_CONTAINER_ID = "container_id";
+    private static final String SPARK_APPLICATION_ID = "application_id";
 
-  private boolean isSparkApplication = false;
+    private boolean isSparkApplication = false;
 
-  // Visible for testing
-  protected boolean verifiedSparkApplication = false;
-  private String applicationId = "";
-  private String containerId = "";
+    // Visible for testing
+    protected boolean verifiedSparkApplication = false;
+    private String applicationId = "";
+    private String containerId = "";
 
-  private final List<LoggingEvent> buffer = new ArrayList<>();
+    private HttpManager httpManager;
+    private String address;
+    private HttpStream stream;
 
-  private HttpManager httpManager;
-  private String address;
-  private HttpStream stream;
+    /**
+     * JSON serializer
+     */
+    protected final JsonParser jsonParser = new JsonParser();
 
-  /**
-   * JSON serializer
-   */
-  protected final JsonParser jsonParser = new JsonParser();
+    /**
+     * Maximum buffer size.
+     */
+    private int bufferSize = 8192;
+    private FiniteDuration flushDuration = Duration.create(3, "seconds");
 
-  /**
-   * Maximum buffer size.
-   */
-  private int bufferSize = 8192;
-  private FiniteDuration flushDuration = Duration.create(3,"seconds");
+    /**
+     * Flush size
+     */
+    private int flushSize = 100;
 
-  /**
-   * Does appender block when buffer is full.
-   */
-  private boolean blocking = false;
+    private String hostname = null;
 
-  private String hostname = null;
-  private Thread dispatcher;
-
-  public HttpAppender() {
-    try {
-      this.hostname = java.net.InetAddress.getLocalHost().getHostName();
-    } catch (UnknownHostException e) {
-      LogLog.error("Could not set hostname: " + e, e);
-    }
-
-    httpManager = this.getHttpManager();
-    stream = new HttpStream(flushDuration, bufferSize, httpManager);
-
-    this.verifiedSparkApplication = Util.isSparkApplication();
-    if (verifiedSparkApplication) {
-        this.applicationId = Util.getApplicationId();
-        this.containerId = Util.getContainerId();
-    }
-
-    try {
-      // Shutdown hook will flush log buffers
-      Runtime.getRuntime().addShutdownHook(new Thread()
-      {
-        public void run()
-        {
-          LogLog.debug("HttpAppender shutdown hook called");
-          HttpAppender.this.close();
-          LogLog.debug("HttpAppender shutdown hook finished");
-        }
-      });
-    } catch(Exception e) {
-      LogLog.debug("Failed to add HttpAppender shutdown hook", e);
-    }
-  }
-
-  /**
-   * Append an event to the buffer.
-   * All events will be flushed ff the event is ERROR level or the buffer has reached its max size.
-   *
-   * @param event The log event.
-   */
-  @Override
-  protected void append(LoggingEvent event) {
-    if (event.getProperty(HOSTNAME) == null) {
-      event.setProperty(HOSTNAME, hostname);
-    }
-
-    if (this.verifiedSparkApplication) {
-      event.setProperty(SPARK_APPLICATION_ID, this.applicationId);
-      event.setProperty(SPARK_CONTAINER_ID, this.containerId);
-    }
-
-    // log immediately if dispatcher thread is dead
-    if ((dispatcher == null) || !dispatcher.isAlive() || (bufferSize <= 0)) {
-      String json;
-      try {
-        json = jsonParser.marshallEvent(event);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-      stream.append(event);
-    }
-
-    // Set the NDC and thread name for the calling thread as these
-    // LoggingEvent fields were not set at event creation time.
-    event.getNDC();
-    event.getThreadName();
-    // Get a copy of this thread's MDC.
-    event.getMDCCopy();
-    event.getRenderedMessage();
-    event.getThrowableStrRep();
-
-    synchronized (buffer) {
-      while (true) {
-        int previousSize = buffer.size();
-
-        if (previousSize < bufferSize) {
-          buffer.add(event);
-
-          // if buffer had been empty signal all threads waiting on buffer to check their conditions.
-          if (previousSize == 0) {
-            buffer.notifyAll();
-          }
-
-          break;
+    public HttpAppender() {
+        try {
+            this.hostname = java.net.InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            LogLog.error("Could not set hostname: " + e, e);
         }
 
-        //   Following code is only reachable if buffer is full
-        //
-        //   if blocking and thread is not already interrupted and not the dispatcher then wait for a buffer notification
-        boolean discard = true;
-        if (blocking
-                && !Thread.interrupted()
-                && Thread.currentThread() != dispatcher) {
-          try {
-            buffer.wait();
-            discard = false;
-          } catch (InterruptedException e) {
-            //  reset interrupt status so calling code can see interrupt on their next wait or sleep.
-            Thread.currentThread().interrupt();
-          }
+        this.verifiedSparkApplication = Util.isSparkApplication();
+        if (verifiedSparkApplication) {
+            this.applicationId = Util.getApplicationId();
+            this.containerId = Util.getContainerId();
         }
 
-        // if blocking is false or thread has been interrupted print warning.
-        if (discard) {
-          String loggerName = event.getLoggerName();
-          LogLog.warn("Discarding LoggingEvent from: " + loggerName);
-
-          break;
+        try {
+            // Shutdown hook will flush log buffers
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+                public void run() {
+                    LogLog.debug("HttpAppender shutdown hook called");
+                    HttpAppender.this.close();
+                    LogLog.debug("HttpAppender shutdown hook finished");
+                }
+            });
+        } catch (Exception e) {
+            LogLog.debug("Failed to add HttpAppender shutdown hook", e);
         }
-      }
     }
-  }
-
-
-  @Override
-  public void close() {
-    /**
-     * Set closed flag and notify all threads to check their conditions.
-     * Should result in dispatcher terminating.
-     */
-    synchronized (buffer) {
-      closed = true;
-      buffer.notifyAll();
-    }
-
-    try {
-      dispatcher.join();
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      org.apache.log4j.helpers.LogLog.error(
-              "Got an InterruptedException while waiting for the "
-                      + "dispatcher to finish.", e);
-    }
-
-    try {
-      httpManager.close();
-    } catch (IOException ie) {
-      LogLog.error("Unexpected exception while closing HttpManager.", ie);
-    }
-  }
-
-  @Override
-  public boolean requiresLayout() {
-    return false;
-  }
-
-  public String getAddress() {
-    return address;
-  }
-
-  public void setAddress(String address) {
-    this.address = address;
-  }
-
-  /**
-   * Force bufferSize to be at least 1.
-   *
-   * @param size must be greater than zero
-   */
-  public void setBufferSize(int size) {
-    synchronized (buffer) {
-      this.bufferSize = (size < 1) ? 1 : size;
-      buffer.notifyAll();
-    }
-  }
-
-  /**
-   * Force bufferSize to be at least 1.
-   *
-   * @param size must be greater than zero
-   */
-  public void setbuffersize(int size) {
-    synchronized (buffer) {
-      this.bufferSize = (size < 1) ? 1 : size;
-      buffer.notifyAll();
-    }
-  }
-
-  /**
-   * Determine if the appender should block when the buffer is full. Default value is true.
-   *
-   * @param blocking boolean
-   */
-  public void setBlocking(boolean blocking) {
-    synchronized (buffer) {
-      this.blocking = blocking;
-      buffer.notifyAll();
-    }
-  }
-
-  @Override
-  public void activateOptions() {
-    if (this.address == null) {
-      throw new NullPointerException("Logger config 'Address' not set");
-    } else {
-      httpManager = new HttpManager(URI.create(this.address));
-    }
-
-    dispatcher = new Thread(new Dispatcher(this, buffer, httpManager), "HTTP appender dispatcher");
-    dispatcher.setDaemon(true);
-    dispatcher.start();
-  }
-
-  /**
-   * Visible for testing.
-   *
-   * @param httpStream handles http connections
-   */
-
-  protected void setHttpStream(HttpStream httpStream) {
-    this.stream = httpStream;
-  }
-  protected HttpManager getHttpManager() {
-    return httpManager;
-  }
-
-
-  /**
-   * Logging event dispatcher. Operates on Object#wait() and Object#notifiy();
-   */
-  private static class Dispatcher implements Runnable {
 
     /**
-     * Parent AsyncAppender.
-     */
-    private final HttpAppender parent;
-
-    /**
-     * Event buffer.
-     */
-    private final List<LoggingEvent> buffer;
-
-    /**
-     * Manager of HTTP connections.
-     */
-    private final HttpManager manager;
-
-
-    /**
-     * Create new instance of dispatcher.
+     * Append an event to the buffer.
+     * All events will be flushed ff the event is ERROR level or the buffer has reached its max size.
      *
-     * @param parent  parent AsyncAppender, may not be null.
-     * @param buffer  event buffer, may not be null.
-     * @param manager http connection manager, may not be null.
+     * @param event The log event.
      */
-    Dispatcher(final HttpAppender parent, final List<LoggingEvent> buffer, final HttpManager manager) {
-
-      this.parent = parent;
-      this.buffer = buffer;
-      this.manager = manager;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public void run() {
-      boolean isActive = true;
-
-      // if interrupted, end thread
-      try {
-        // loop until the HttpAppender is closed.
-        while (isActive) {
-          LoggingEvent[] events = null;
-
-          // extract pending events while synchronized on buffer
-          synchronized (buffer) {
-            int bufferSize = buffer.size();
-            isActive = !parent.closed;
-
-            while ((bufferSize == 0) && isActive) {
-              buffer.wait();
-              bufferSize = buffer.size();
-              isActive = !parent.closed;
-            }
-
-            if (bufferSize > 0) {
-              events = new LoggingEvent[bufferSize];
-              buffer.toArray(events);
-
-              buffer.clear();
-
-              // allow blocked appends to continue
-              buffer.notifyAll();
-            }
-          }
-
-          // process events after lock on buffer is released.
-          if (events != null) {
-            flush(events);
-          }
+    @Override
+    protected void append(LoggingEvent event) {
+        if (event.getProperty(HOSTNAME) == null) {
+            event.setProperty(HOSTNAME, hostname);
         }
-      } catch (InterruptedException ex) {
-        Thread.currentThread().interrupt();
-      }
+
+        if (this.verifiedSparkApplication) {
+            event.setProperty(SPARK_APPLICATION_ID, this.applicationId);
+            event.setProperty(SPARK_CONTAINER_ID, this.containerId);
+        }
+
+        // Set the NDC and thread name for the calling thread as these
+        // LoggingEvent fields were not set at event creation time.
+        event.getNDC();
+        event.getThreadName();
+        // Get a copy of this thread's MDC.
+        event.getMDCCopy();
+        event.getRenderedMessage();
+        event.getThrowableStrRep();
+
+        stream.append(event);
+    }
+
+
+    @Override
+    public void close() {
+        try {
+            httpManager.close();
+        } catch (IOException ie) {
+            LogLog.error("Unexpected exception while closing HttpManager.", ie);
+        }
+    }
+
+    @Override
+    public boolean requiresLayout() {
+        return false;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
     }
 
     /**
-     * Serialize the log events to JSON and post to the HTTP service.
+     * Force bufferSize to be at least 1.
+     *
+     * @param size must be greater than zero
      */
-    void flush(LoggingEvent[] events) {
-      String json;
-      try {
-        json = parent.jsonParser.marshallArray(events);
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-      manager.send(json);
-    }
-  }
+    public void setBufferSize(int size) {
 
+        if (this.bufferSize < 1) {
+            throw new IllegalArgumentException("Buffer size must be greater than zero");
+        }
+        this.bufferSize = size;
+    }
+
+    /**
+     * Force bufferSize to be at least 1.
+     *
+     * @param size must be greater than zero
+     */
+    public void setbuffersize(int size) {
+        this.setBufferSize(size);
+    }
+
+    @Override
+    public void activateOptions() {
+        if (this.getAddress() == null) {
+            throw new NullPointerException("Logger config 'Address' not set");
+        } else {
+            httpManager = new HttpManager(URI.create(this.address));
+            this.stream = new HttpStream(this.flushDuration, this.flushSize, this.bufferSize, this.httpManager);
+        }
+    }
+
+    /**
+     * Visible for testing.
+     *
+     * @param httpStream handles http connections
+     */
+
+    protected void setHttpStream(HttpStream httpStream) {
+        this.stream = httpStream;
+    }
+
+    protected HttpManager getHttpManager() {
+        return httpManager;
+    }
 }

--- a/log-appender/src/test/java/io/phdata/pulse/log/HttpAppenderTest.java
+++ b/log-appender/src/test/java/io/phdata/pulse/log/HttpAppenderTest.java
@@ -39,7 +39,7 @@ public class HttpAppenderTest {
 
     Mockito.when(httpManager.send(Matchers.any())).thenReturn(true);
 
-    HttpStream httpStream = new HttpStream(duration, 10, httpManager);
+    HttpStream httpStream = new HttpStream(duration, 10, 100, httpManager);
 
     // first event should call 'send'
     httpStream.append(event);

--- a/log-appender/src/test/java/io/phdata/pulse/log/SLF4j.java
+++ b/log-appender/src/test/java/io/phdata/pulse/log/SLF4j.java
@@ -1,0 +1,19 @@
+package io.phdata.pulse.log;
+
+
+import org.apache.log4j.Logger;
+
+
+public class SLF4j {
+    public static void main(String[] args) {
+
+        Logger logger = Logger.getLogger(SLF4j.class);
+
+        final String message = "Hello logging!";
+        logger.trace(message);
+        logger.debug(message);
+        logger.info(message);
+        logger.warn(message);
+        logger.error(message);
+    }
+}

--- a/log-appender/src/test/scala/io/phdata/pulse/StreamTest.scala
+++ b/log-appender/src/test/scala/io/phdata/pulse/StreamTest.scala
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package io.phdata.pulse.metrics
+package io.phdata.pulse
 
 import java.util.concurrent.TimeUnit
 
-import io.phdata.pulse.Stream
 import org.scalatest.FunSuite
 
 import scala.collection.mutable
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration._
 
-class TestStream(flushDuration: FiniteDuration, flushSize: Int) extends Stream[String](flushDuration, flushSize) {
+class TestStream(flushDuration: FiniteDuration, flushSize: Int, maxBuffer: Int)
+    extends Stream[String](flushDuration, flushSize, maxBuffer) {
   var results: mutable.Seq[String] = mutable.Seq()
 
   override def save(values: Seq[String]): Unit =
@@ -34,8 +34,12 @@ class TestStream(flushDuration: FiniteDuration, flushSize: Int) extends Stream[S
 
 class StreamTest extends FunSuite {
 
+  val DEFAULT_MAX_BUFFER = 1000
+  val DEFAULT_FLUSH_SIZE = 10
+
   test("should flush after n events") {
-    val stream = new TestStream(Duration(1,TimeUnit.SECONDS), 10)
+    val stream =
+      new TestStream(1 seconds, DEFAULT_FLUSH_SIZE, DEFAULT_MAX_BUFFER)
 
     (1 to 10).foreach(x => stream.append((x.toString)))
     Thread.sleep(2500)
@@ -43,10 +47,12 @@ class StreamTest extends FunSuite {
   }
 
   test("should flush after n second") {
-    val stream = new TestStream(Duration(1,TimeUnit.SECONDS), 10)
+    val stream =
+      new TestStream(1 seconds, DEFAULT_FLUSH_SIZE, DEFAULT_MAX_BUFFER)
 
     (1 to 3).foreach(x => stream.append((x.toString)))
-    Thread.sleep(2000)
+    Thread.sleep(3000)
     assert(stream.results.length === 3)
   }
+
 }


### PR DESCRIPTION
- Initialize HttpManager in `activateOptions` so the address is not null
- Remove old HttpManager buffering code
- This removes the 'blocking' option from the configuration since
blocking in the stream is no longer possible